### PR TITLE
16 refactor improve performance of nemodataarray methods

### DIFF
--- a/nemo_cookbook/extract.py
+++ b/nemo_cookbook/extract.py
@@ -163,7 +163,9 @@ def create_boundary_dataset(
 def get_section_indexes(
     lon_section: np.ndarray,
     lat_section: np.ndarray,
-    ds_bdy: xr.Dataset,
+    gphib: np.ndarray,
+    glamb: np.ndarray,
+    bdy: np.ndarray,
 ) -> list[int]:
     """
     Get indexes along a mask boundary corresponding to the start
@@ -175,8 +177,12 @@ def get_section_indexes(
         Longitudes defining hydrographic section.
     lat_section : np.ndarray
         Latitudes defining hydrographic section.
-    ds_bdy : xr.Dataset
-        Dataset containing mask boundary indexes.
+    gphib : np.ndarray
+        Latitudes of boundary points.
+    glamb : np.ndarray
+        Longitudes of boundary points.
+    bdy : np.ndarray
+        Boundary indexes.
 
     Returns
     -------
@@ -184,7 +190,7 @@ def get_section_indexes(
         List of boundary indexes corresponding to the hydrographic section.
     """
     # -- Find indexes of boundary start and end points -- #
-    bdy_points = np.array(list(zip(ds_bdy["gphib"].values, ds_bdy["glamb"].values, strict=True)))
+    bdy_points = np.array(list(zip(gphib, glamb, strict=True)))
     geoballtree = SklearnGeoBallTreeAdapter(points=bdy_points, options={})
 
     # Collect indices of nearest boundary points to start and end points of section:
@@ -193,10 +199,10 @@ def get_section_indexes(
 
     # -- Define section in terms of boundary indexes -- #
     if bdy_start.size > 1:
-        if (bdy_start[0] == 0) and (bdy_start[-1] == ds_bdy["bdy"][-1]):
+        if (bdy_start[0] == 0) and (bdy_start[-1] == bdy[-1]):
             bdy_start = bdy_start[0]
     if bdy_end.size > 1:
-        if (bdy_end[0] == 0) and (bdy_end[-1] == ds_bdy["bdy"][-1]):
+        if (bdy_end[0] == 0) and (bdy_end[-1] == bdy[-1]):
             bdy_end = bdy_end[0]
 
     sec_start, sec_end = int(bdy_start.item()), int(bdy_end.item())
@@ -205,7 +211,7 @@ def get_section_indexes(
     elif sec_end < sec_start:
         # Note: start and end indexes are duplicated to close boundary -> do not include final index:
         sec_indexes = np.concatenate(
-            [np.arange(sec_start, ds_bdy["bdy"][-2] + 1), np.arange(0, sec_end + 1)]
+            [np.arange(sec_start, bdy[-2] + 1), np.arange(0, sec_end + 1)]
         ).tolist()
     else:
         raise ValueError(

--- a/nemo_cookbook/extract.py
+++ b/nemo_cookbook/extract.py
@@ -193,10 +193,10 @@ def get_section_indexes(
 
     # -- Define section in terms of boundary indexes -- #
     if bdy_start.size > 1:
-        if (bdy_start[0] == 0) & (bdy_start[-1] == ds_bdy["bdy"][-1]):
+        if (bdy_start[0] == 0) and (bdy_start[-1] == ds_bdy["bdy"][-1]):
             bdy_start = bdy_start[0]
     if bdy_end.size > 1:
-        if (bdy_end[0] == 0) & (bdy_end[-1] == ds_bdy["bdy"][-1]):
+        if (bdy_end[0] == 0) and (bdy_end[-1] == ds_bdy["bdy"][-1]):
             bdy_end = bdy_end[0]
 
     sec_start, sec_end = int(bdy_start.item()), int(bdy_end.item())

--- a/nemo_cookbook/masks.py
+++ b/nemo_cookbook/masks.py
@@ -69,6 +69,49 @@ def read_dom_mask(
     return mask
 
 
+def read_dom_maskutil(
+    ds_domain: xr.Dataset,
+    cd_nat: str,
+) -> xr.DataArray:
+    """
+    Read land/ocean mask arrays at tracer points, horizontal velocity
+    points (u & v) and vorticity points (f) points from domain dataset.
+
+    Expected dimensions are: (y, x) for 2D arrays. All dimensions are
+    expected to use zero-based indexing.
+
+    Parameters
+    ----------
+    ds_domain : xr.Dataset
+        NEMO model domain dataset.
+    cd_nat : str
+        Nature of array grid-points to read land/sea mask for.
+        Options are 'T', 'W', 'U', 'V' or 'F'.
+
+    Returns
+    -------
+    xr.DataArray
+        Read land/ocean mask for the specified grid point type.
+    """
+    if not isinstance(ds_domain, xr.Dataset):
+        raise TypeError("ds_domain must be an xarray Dataset")
+    if cd_nat not in ["T", "U", "V", "W", "F"]:
+        raise ValueError("cd_nat must be one of 'T', 'U', 'V', 'W', or 'F'")
+
+    # -- Read mask from domain dataset -- #
+    try:
+        mask = ds_domain[f"{cd_nat.lower()}maskutil"]
+    except AttributeError as e:
+        raise AttributeError(
+            f"missing '{cd_nat.lower()}maskutil' variable in domain dataset"
+        ) from e
+
+    # Update coordinates to use zero-based indexing:
+    mask = mask.assign_coords({"y": mask["y"], "x": mask["x"]})
+
+    return mask
+
+
 def create_dom_mask(
     ka: xr.DataArray,
     top_level: xr.DataArray,

--- a/nemo_cookbook/masks.py
+++ b/nemo_cookbook/masks.py
@@ -452,7 +452,7 @@ def get_mask_boundary(mask: xr.DataArray) -> list[list[int]]:
     for point in bdy_points:
         jp, ip = point[0], point[1]
         # Classify grid cell face of point - zonal:
-        if (jp % 1 == 0) & (ip % 1 != 0):
+        if (jp % 1 == 0) and (ip % 1 != 0):
             flux_type.append("U")
             # Classify flux direction across grid cell face:
             i_w, i_e = int(ip - 0.5), int(ip + 0.5)
@@ -470,7 +470,7 @@ def get_mask_boundary(mask: xr.DataArray) -> list[list[int]]:
                 )
 
         # Classify grid cell face of point - meridional:
-        elif (jp % 1 != 0) & (ip % 1 == 0):
+        elif (jp % 1 != 0) and (ip % 1 == 0):
             flux_type.append("V")
             # Classify flux direction across meridional grid cell face:
             j_s, j_n = int(jp - 0.5), int(jp + 0.5)

--- a/nemo_cookbook/nemodataarray.py
+++ b/nemo_cookbook/nemodataarray.py
@@ -97,20 +97,20 @@ class NEMODataArray:
                 f"{self._grid} not found in available NEMODataTree grids {grid_keys}."
             )
 
-        # Dimension must exist & values must be within NEMODataTree dimension values:
+        # Dimension must exist & sizes must be less than or equal to NEMODataTree dimensions:
         if not all(dim in list(self._tree[self._grid].dims) for dim in self._da.dims):
             raise ValueError(f"DataArray dimensions {self._da.dims} not all in NEMO model '{self._grid}' dimensions {self._tree[self._grid].dims}.")
 
-        if not all((self._da[dim].min() >= self._tree[self._grid][dim].min()) & (self._da[dim].max() <= self._tree[self._grid][dim].max()) for dim in self._da.dims):
-            raise ValueError(f"DataArray dimension values {self._da.dims} not all within NEMO model '{self._grid}' dimension values {self._tree[self._grid].dims}.")
+        if not all(self._da.sizes[d] <= self._tree[self._grid].sizes[d] for d in self._da.dims):
+            raise ValueError(f"DataArray dimension sizes {self._da.dims} not all less than or equal to NEMO model '{self._grid}' dimension sizes {self._tree[self._grid].dims}.")
 
-        # Core coordinates (glam, gphi, depth, time_counter) must exist & values must be within NEMODataTree coordinate values:
+        # Core coordinates (glam, gphi, depth, time_counter) must exist & sizes must be less than or equal to NEMODataTree coordinates:
         core_coords = [coord for coord in self._da.coords if "glam" in coord or "gphi" in coord or "depth" in coord or "time_counter" in coord]
         if not all(dim in list(self._tree[self._grid].coords) for dim in core_coords):
             raise ValueError(f"DataArray coordinates {core_coords} not all in NEMO model '{self._grid}' coordinates {self._tree[self._grid].coords}.")
 
-        if not all((self._da[coord].min() >= self._tree[self._grid].coords[coord].min()) & (self._da[coord].max() <= self._tree[self._grid].coords[coord].max()) for coord in core_coords):
-            raise ValueError(f"DataArray coordinate values {core_coords} not all within NEMO model '{self._grid}' coordinate values {self._tree[self._grid].coords}.")
+        if not all(self._da[coord].sizes[d] <= self._tree[self._grid].coords[coord].sizes[d] for coord in core_coords for d in self._da[coord].dims):
+            raise ValueError(f"DataArray coordinate sizes {core_coords} not all less than or equal to NEMO model '{self._grid}' coordinate sizes {self._tree[self._grid].coords}.")
 
         # -- Assign NEMO domain number, grid path and grid type -- #
         dom, dom_prefix, dom_suffix, grid_suffix = self._tree._get_properties(grid=self._grid, infer_dom=True)

--- a/nemo_cookbook/nemodataarray.py
+++ b/nemo_cookbook/nemodataarray.py
@@ -335,6 +335,7 @@ class NEMODataArray:
     def weighted_mean(
         self,
         dims : list,
+        mask: xr.DataArray | None = None,
         skipna : bool | None = None
     ) -> Self:
         """
@@ -344,6 +345,9 @@ class NEMODataArray:
         ----------
         dims : list
             Dimensions over which to apply weighted mean (e.g., ['i', 'j']).
+        mask: xr.DataArray, optional
+            Boolean mask identifying NEMO model grid points to be included (1)
+            or neglected (0) from integration.
         skipna : bool | None
             If True, skip missing values (as marked by NaN).
             By default, only skips missing values for float dtypes.
@@ -367,14 +371,22 @@ class NEMODataArray:
         # -- Validate Input -- #
         if not isinstance(dims, list):
             raise TypeError("dims must be specified as a list.")
+        if mask is not None:
+            if not isinstance(mask, xr.DataArray):
+                raise TypeError("mask must be an xarray.DataArray.")
+            if any(dim not in self.dims for dim in mask.dims):
+                raise ValueError(
+                    f"mask must have dimensions subset from {self.dims}."
+                )
         if skipna is not None:
             if not isinstance(skipna, bool):
                 raise TypeError("skipna must be specified as a boolean or None.")
 
         # -- Calculate weighted mean & return NEMODataArray -- #
+        da = self.apply_mask(mask=mask).data
         weight_dims = [dim.replace(self._dom_suffix, "") for dim in dims]
         weights = self._tree._get_weights(grid=self._grid, dims=weight_dims)
-        result = self.weighted(weights).mean(dim=dims, skipna=skipna)
+        result = da.weighted(weights).mean(dim=dims, skipna=skipna)
         result.name = f"wmean_{'_'.join(dims)}({self.name})"
 
         return self._wrap(result)
@@ -397,7 +409,9 @@ class NEMODataArray:
         Returns
         -------
         NEMODataArray
-            Discrete difference of variable defined on a NEMO model grid.
+            Discrete difference of variable defined on a new NEMO model grid. For example, the
+            discrete difference along the i-dimension of a scalar variable defined on a T-grid
+            returns a NEMODataArray defined on the U-grid. 
 
         Examples
         --------
@@ -753,7 +767,7 @@ class NEMODataArray:
         --------
         integral
         """
-        # -- Validate input -- #
+        # -- Validate Input -- #
         if (not isinstance(limits, tuple)) | (len(limits) != 2):
             raise TypeError(
                 "depth limits of integration should be given by a tuple of the form (depth_min, depth_max)"

--- a/nemo_cookbook/nemodataarray.py
+++ b/nemo_cookbook/nemodataarray.py
@@ -1041,7 +1041,7 @@ class NEMODataArray:
         --------
         transform_to
         """
-        # -- Validate input -- #
+        # -- Validate Input -- #
         if e3_new.dims != ("k_new",) or (e3_new.ndim != 1):
             raise ValueError(
                 "e3_new must be a 1-dimensional xarray.DataArray with dimension 'k_new'."
@@ -1050,9 +1050,12 @@ class NEMODataArray:
         # -- Define input variables -- #
         var_in = self.masked.data
         e3_in = self.metrics["e3"].masked.data
-        if e3_new.sum(dim="k_new") < var_in[f"depth{self._grid_suffix}"].max(dim=self.k_name):
+
+        # Ensure total depth of new vertical grid >= total depth of NEMO model vertical grid:
+        depth_max = self._tree[self._grid][f"{self._dom_prefix}depth{self._grid_suffix}"].max(self.k_name)
+        if e3_new.sum(dim="k_new") < depth_max:
             raise ValueError(
-                f"e3_new must sum to at least the maximum depth ({var_in[f'depth{self._grid_suffix}'].max(dim=self.k_name).item()} m) of the original vertical grid."
+                f"e3_new must sum to at least the maximum depth ({depth_max.item()} m) of the original vertical grid."
             )
 
         # -- Transform variable to target vertical grid -- #

--- a/nemo_cookbook/nemodataarray.py
+++ b/nemo_cookbook/nemodataarray.py
@@ -17,6 +17,7 @@ import warnings
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Self
 
+import dask
 import numpy as np
 import xarray as xr
 
@@ -264,8 +265,8 @@ class NEMODataArray:
             mask = (self.mask & mask)
 
         # -- Apply mask & return NEMODataArray -- #
-        if drop:
-            warnings.warn(message="Indexing with a boolean dask array is not allowed. Mask will be computed first using .compute(). This may result in high memory usage for large masks.",
+        if drop and isinstance(mask.data, dask.array.Array):
+            warnings.warn(message="Indexing with a boolean dask array is not allowed. Mask will be materialised first using .load(). This may result in high memory usage for large masks.",
                           category=RuntimeWarning,
                           stacklevel=2
                           )

--- a/nemo_cookbook/nemodataarray.py
+++ b/nemo_cookbook/nemodataarray.py
@@ -179,7 +179,7 @@ class NEMODataArray:
         if (self._da.ndim == 1) and (self.t_name in self._da.dims):
             raise ValueError("land-sea mask does not exist for variables without spatial dimensions.")
         else:
-            if (f"{self._dom_prefix}depth{self._grid_suffix}" in self._da.coords) & (self.k_name in self._da.dims):
+            if (f"{self._dom_prefix}depth{self._grid_suffix}" in self._da.coords) and (self.k_name in self._da.dims):
                 # 3-dimensional land-sea mask:
                 mask_name = f"{self._grid_suffix}mask"
             else:

--- a/nemo_cookbook/nemodataarray.py
+++ b/nemo_cookbook/nemodataarray.py
@@ -324,10 +324,14 @@ class NEMODataArray:
                 if other.coords[dim].size != self.data.coords[dim].size:
                     d_dims[dim] = other.coords[dim].data
 
-        result = self.data.sel(d_dims)
+        # Indexing only required if dimensions modified:
+        if len(d_dims) > 0:
+            result = self.data.sel(d_dims)
+            return self._wrap(result)
+        # Otherwise return original NEMODataArray:
+        else:
+            return self
 
-        return self._wrap(result)
-    
     def weighted_mean(
         self,
         dims : list,
@@ -593,9 +597,9 @@ class NEMODataArray:
         # Define path to derivative NEMO model grid:
         new_grid = f"{self._grid.replace(self._grid[-1], new_grid_suffix.upper())}"
 
-        # Collect & mask derivative grid scale factors (e.g., e1u, e3t etc.):
+        # Collect derivative grid scale factors (e.g., e1u, e3t etc.):
         try:
-            weights = self._tree[f"{new_grid}/{new_grid_weights}"].masked
+            weights = self._tree[new_grid][new_grid_weights]
         except KeyError as e:
             raise KeyError(
                 f"NEMO model grid: '{new_grid}' does not contain grid scale factor '{new_grid_weights}' required to calculate derivatives along the {dim}-dimension."
@@ -607,10 +611,10 @@ class NEMODataArray:
         # Calculate derivative (i.e., diff(var) / e{1/2/3}{t/u/v/w}):
         if dim in [self.k_name]:
             # Vertical derivative [k increasing downward]:
-            result = - da.data / weights.data
+            result = - da.data / weights
         else:
             # Horizontal derivative [i/j increasing eastward/northward]:
-            result = da.data / weights.data
+            result = da.data / weights
 
         # -- Update DataArray properties & return NEMODataArray -- #
         result.name = f"d({self.name})/d{dim}"
@@ -669,7 +673,7 @@ class NEMODataArray:
         --------
         depth_integral
         """
-        # -- Validate input -- #
+        # -- Validate Input -- #
         if cum_dims is not None:
             for dim in cum_dims:
                 if dim not in dims:
@@ -689,11 +693,7 @@ class NEMODataArray:
                 )
 
         # -- Collect variable, weights & mask -- #
-        da = (
-            self.masked.data.where(mask)
-            if mask is not None
-            else self.masked.data
-            )
+        da = self.apply_mask(mask=mask).data
         weights = self._tree._get_weights(grid=self._grid, dims=dims)
 
         # -- Perform integration -- #
@@ -853,7 +853,7 @@ class NEMODataArray:
         )
 
         # -- Apply masks & calculate statistic -- #
-        da = self.masked.data.where(mask_poly)
+        da = self.apply_mask(mask=mask_poly).data
 
         match statistic:
             case "mean":

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -623,7 +623,7 @@ class NEMODataTree(xr.DataTree):
             "k": f"e3{grid_suffix}",
         }
         try:
-            weights_list = [self[f"{grid}/{weights_dict[dim]}"].masked.data for dim in dims]
+            weights_list = [self[f"{grid}"][weights_dict[dim]] for dim in dims]
         except KeyError as e:
             raise KeyError(
                 f"weights missing for dimensions {dims} of NEMO model grid {grid}"

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -426,7 +426,7 @@ class NEMODataTree(xr.DataTree):
         if isinstance(value, NEMODataArray):
             value = value.data
 
-        if validate & isinstance(value, xr.Dataset):
+        if validate and isinstance(value, xr.Dataset):
             # Define suffix NEMO grid node:
             grid_type = key[-1].lower()
             hgrid_type = grid_type if "w" not in grid_type else "t"
@@ -471,7 +471,7 @@ class NEMODataTree(xr.DataTree):
         is_gridpath = key.startswith("/grid") or key.startswith("grid")
 
         # -- Return NEMODataArray -- #
-        if isinstance(item, xr.DataArray) & is_gridpath:
+        if isinstance(item, xr.DataArray) and is_gridpath:
             var_name = key.split("/")[-1]
             grid = key.replace(f"/{var_name}", "")
             item = NEMODataArray(da=item,
@@ -512,7 +512,7 @@ class NEMODataTree(xr.DataTree):
         tuple[str]
             NEMO model domain and grid properties.
         """
-        if (grid is None) & (dom is not None):
+        if (grid is None) and (dom is not None):
             dom_prefix = "" if dom == "." else f"{dom}_"
             dom_suffix = "" if dom == "." else f"{dom}"
             return dom_prefix, dom_suffix
@@ -552,7 +552,7 @@ class NEMODataTree(xr.DataTree):
 
         if dom == ".":
             grid_paths = [
-                path for path in grid_paths if ("_" not in path) & ("grid" in path)
+                path for path in grid_paths if ("_" not in path) and ("grid" in path)
             ]
         else:
             grid_paths = [path for path in grid_paths if dom in path]
@@ -1007,7 +1007,7 @@ class NEMODataTree(xr.DataTree):
         da_j = self[f"{gridV}/{var_j}"].masked.data
 
         # -- Collect mask -- #
-        if (f"{dom_prefix}depthu" in da_i.coords) & (
+        if (f"{dom_prefix}depthu" in da_i.coords) and (
             f"{dom_prefix}depthv" in da_j.coords
         ):
             # 3-dimensional tmask:
@@ -1120,7 +1120,7 @@ class NEMODataTree(xr.DataTree):
         da_j = self[f"{gridV}/{var_j}"].masked.data
 
         # -- Collect mask -- #
-        if (f"{dom_prefix}depthu" in da_i.coords) & (
+        if (f"{dom_prefix}depthu" in da_i.coords) and (
             f"{dom_prefix}depthv" in da_j.coords
         ):
             # 3-dimensional fmask

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -483,7 +483,7 @@ class NEMODataTree(xr.DataTree):
 
     def _get_properties(
         self, dom: str | None = None, grid: str | None = None, infer_dom: bool = False
-    ) -> str:
+    ) -> str | tuple[str, ...]:
         """
         Get NEMO model domain and grid properties.
 
@@ -509,7 +509,7 @@ class NEMODataTree(xr.DataTree):
 
         Returns
         -------
-        tuple[str]
+        str | tuple[str, ...]
             NEMO model domain and grid properties.
         """
         if (grid is None) and (dom is not None):
@@ -533,7 +533,7 @@ class NEMODataTree(xr.DataTree):
             else:
                 return grid_suffix
 
-    def _get_grid_paths(self, dom: str) -> str:
+    def _get_grid_paths(self, dom: str) -> dict[str, str]:
         """
         Get paths to NEMO model grids in a given domain.
 
@@ -561,7 +561,7 @@ class NEMODataTree(xr.DataTree):
 
         return d_paths
 
-    def _get_ijk_names(self, dom: str | None = None, grid: str | None = None) -> str:
+    def _get_ijk_names(self, dom: str | None = None, grid: str | None = None) -> dict[str, str]:
         """
         Get (i, j, k) grid index names for given NEMO model domain.
 

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -12,7 +12,6 @@ Ollie Tooth (oliver.tooth@noc.ac.uk)
 
 from typing import Self
 
-import dask
 import numpy as np
 import xarray as xr
 from xarray.indexes import NDPointIndex
@@ -1754,141 +1753,53 @@ class NEMODataTree(xr.DataTree):
         --------
         extract_section
         """
-        # -- Validate input -- #
+        # -- Validate Input -- #
         if not isinstance(mask, xr.DataArray):
-            raise ValueError("mask must be an xarray DataArray")
+            raise TypeError("mask must be an xarray DataArray")
         if not isinstance(dom, str):
-            raise ValueError(
+            raise TypeError(
                 "dom must be a string specifying prefix of a NEMO domain (e.g., '.', '1', '2', etc.)."
             )
         if uv_vars is None:
             uv_vars = ["uo", "vo"]
         else:
             if not isinstance(uv_vars, list) or len(uv_vars) != 2:
-                raise ValueError(
+                raise TypeError(
                     "uv_vars must be a list of velocity variables to extract (e.g., ['uo', 'vo'])."
                 )
 
         # -- Get NEMO model grid properties -- #
-        dom_prefix, dom_suffix = self._get_properties(dom=dom)
-        grid_paths = self._get_grid_paths(dom=dom)
-        gridT, gridU, gridV = (
-            grid_paths["gridT"],
-            grid_paths["gridU"],
-            grid_paths["gridV"],
-        )
-        ijk_names = self._get_ijk_names(dom=dom)
-        k_name = ijk_names["k"]
+        _, dom_suffix = self._get_properties(dom=dom)
 
         # -- Extract mask boundary -- #
         if f"i{dom_suffix}" not in mask.dims or f"j{dom_suffix}" not in mask.dims:
             raise ValueError(
-                f"mask must have dimensions f'i{dom_suffix}' and 'j{dom_suffix}'"
+                f"mask must have dimensions 'i{dom_suffix}' and 'j{dom_suffix}'"
             )
         i_bdy, j_bdy, flux_type, flux_dir = get_mask_boundary(mask)
 
         # -- Construct boundary dataset -- #
-        t_name = [dim for dim in self[gridU].dims if "time" in dim][0]
-
-        ds = xr.Dataset(
-            data_vars={
-                "i_bdy": (["bdy"], i_bdy[::-1]),
-                "j_bdy": (["bdy"], j_bdy[::-1]),
-                "flux_type": (["bdy"], flux_type[::-1]),
-                "flux_dir": (["bdy"], flux_dir[::-1]),
-            },
-            coords={
-                t_name: self[gridU][t_name].values,
-                k_name: self[gridU][k_name].values,
-                "bdy": np.arange(len(i_bdy)),
-            },
+        # Neglecting final indices -> duplicate of the first indices:
+        ds_bdy = create_boundary_dataset(
+            nemo=self,
+            dom=dom,
+            i_bdy=i_bdy[:-1],
+            j_bdy=j_bdy[:-1],
+            flux_type=flux_type[:-1],
+            flux_dir=flux_dir[:-1],
         )
 
-        # Add velocities normal to boundary:
-        if uv_vars[0] not in self[gridU].data_vars:
-            raise KeyError(f"variable '{uv_vars[0]}' not found in grid '{gridU}'.")
-        if uv_vars[1] not in self[gridV].data_vars:
-            raise KeyError(f"variable '{uv_vars[1]}' not found in grid '{gridV}'.")
-
-        ubdy_mask = ds["flux_type"] == "U"
-        vbdy_mask = ds["flux_type"] == "V"
-
-        dim_sizes = [
-            self[gridU][t_name].size,
-            self[gridU][k_name].size,
-            ds["bdy"].size,
-        ]
-
-        ds["velocity"] = xr.DataArray(
-            data=dask.array.zeros(dim_sizes), dims=[t_name, k_name, "bdy"]
-        )
-        ds["velocity"][:, :, ubdy_mask] = (
-            self[f"{gridU}/{uv_vars[0]}"].masked.data.sel(
-                i=ds["i_bdy"][ubdy_mask], j=ds["j_bdy"][ubdy_mask]
-            )
-            * ds["flux_dir"][ubdy_mask]
-        )
-        ds["velocity"][:, :, vbdy_mask] = (
-            self[f"{gridV}/{uv_vars[1]}"].masked.data.sel(
-                i=ds["i_bdy"][vbdy_mask], j=ds["j_bdy"][vbdy_mask]
-            )
-            * ds["flux_dir"][vbdy_mask]
+        # -- Update boundary dataset with extracted section data -- #
+        ds_bdy = update_boundary_dataset(
+            ds_bdy=ds_bdy,
+            nemo=self,
+            dom=dom,
+            sec_indexes=None,
+            uv_vars=uv_vars,
+            vars=vars,
         )
 
-        ds = ds.assign_coords(
-            {
-                f"{dom_prefix}glamb": (["bdy"], np.zeros(ds["bdy"].size)),
-                f"{dom_prefix}gphib": (["bdy"], np.zeros(ds["bdy"].size)),
-                f"{dom_prefix}depthb": ((k_name, "bdy"), np.zeros(dim_sizes[1:])),
-            }
-        )
-
-        ds[f"{dom_prefix}glamb"][ubdy_mask] = self[gridU][f"{dom_prefix}glamu"].sel(
-            i=ds["i_bdy"][ubdy_mask], j=ds["j_bdy"][ubdy_mask]
-        )
-        ds[f"{dom_prefix}glamb"][vbdy_mask] = self[gridV][f"{dom_prefix}glamv"].sel(
-            i=ds["i_bdy"][vbdy_mask], j=ds["j_bdy"][vbdy_mask]
-        )
-
-        ds[f"{dom_prefix}gphib"][ubdy_mask] = self[gridU][f"{dom_prefix}gphiu"].sel(
-            i=ds["i_bdy"][ubdy_mask], j=ds["j_bdy"][ubdy_mask]
-        )
-        ds[f"{dom_prefix}gphib"][vbdy_mask] = self[gridV][f"{dom_prefix}gphiv"].sel(
-            i=ds["i_bdy"][vbdy_mask], j=ds["j_bdy"][vbdy_mask]
-        )
-        ds[f"{dom_prefix}depthb"][:, ubdy_mask] = self[gridU][f"{dom_prefix}depthu"]
-        ds[f"{dom_prefix}depthb"][:, vbdy_mask] = self[gridV][f"{dom_prefix}depthv"]
-
-        if vars is not None:
-            # Add scalar variables along the boundary:
-            for var in vars:
-                if var in self[gridT].data_vars:
-                    ds[var] = xr.DataArray(
-                        data=dask.array.zeros(dim_sizes),
-                        dims=[t_name, k_name, "bdy"],
-                    )
-                else:
-                    raise KeyError(f"variable {var} not found in grid '{gridT}'.")
-
-                # Linearly interpolate scalar variables onto NEMO model U/V grid points:
-                ds[var][:, :, ubdy_mask] = 0.5 * (
-                    self[f"{gridT}/{var}"].masked.data.sel(
-                        i=ds["i_bdy"][ubdy_mask] - 0.5, j=ds["j_bdy"][ubdy_mask]
-                    )
-                    + self[f"{gridT}/{var}"].masked.data.sel(
-                        i=ds["i_bdy"][ubdy_mask] + 0.5, j=ds["j_bdy"][ubdy_mask]
-                    )
-                )
-                ds[var][:, :, vbdy_mask] = 0.5 * (
-                    self[f"{gridT}/{var}"].masked.data.sel(
-                        i=ds["i_bdy"][vbdy_mask], j=ds["j_bdy"][vbdy_mask] - 0.5
-                    )
-                    + self[f"{gridT}/{var}"].masked.data.sel(
-                        i=ds["i_bdy"][vbdy_mask], j=ds["j_bdy"][vbdy_mask] + 0.5
-                    )
-                )
-
-        return ds
+        return ds_bdy
 
     def extract_section(
         self,
@@ -1938,20 +1849,20 @@ class NEMODataTree(xr.DataTree):
         --------
         extract_mask_boundary
         """
-        # -- Validate input -- #
+        # -- Validate Input -- #
         if not isinstance(lon_section, np.ndarray):
             raise TypeError("lon_section must be a numpy array.")
         if not isinstance(lat_section, np.ndarray):
             raise TypeError("lat_section must be a numpy array.")
         if not isinstance(dom, str):
-            raise ValueError(
+            raise TypeError(
                 "dom must be a string specifying prefix of a NEMO domain (e.g., '.', '1', '2', etc.)."
             )
         if uv_vars is None:
             uv_vars = ["uo", "vo"]
         else:
             if not isinstance(uv_vars, list) or len(uv_vars) != 2:
-                raise ValueError(
+                raise TypeError(
                     "uv_vars must be a list of velocity variables to extract (e.g., ['uo', 'vo'])."
                 )
 
@@ -1981,10 +1892,13 @@ class NEMODataTree(xr.DataTree):
         )
 
         # -- Get indexes of hydrographic section along mask boundary -- #
+        dom_prefix, _ = self._get_properties(dom=dom)
         sec_indexes = get_section_indexes(
             lon_section=lon_section,
             lat_section=lat_section,
-            ds_bdy=ds_bdy,
+            gphib=ds_bdy[f"{dom_prefix}gphib"].values,
+            glamb=ds_bdy[f"{dom_prefix}glamb"].values,
+            bdy=ds_bdy["bdy"].values,
         )
 
         # -- Update boundary dataset with extracted section data -- #

--- a/nemo_cookbook/processing.py
+++ b/nemo_cookbook/processing.py
@@ -212,7 +212,7 @@ def _check_grid_datasets(d: dict[str, xr.Dataset]) -> dict[str, xr.Dataset]:
             _check_grid_dims(ds=d[key], grid=key)
 
     # Combining sea ice and scalar variables both stored on T-grid:
-    if ("gridT" in d.keys()) & ("icemod" in d.keys()):
+    if ("gridT" in d.keys()) and ("icemod" in d.keys()):
         d["gridT"] = xr.merge([d["icemod"], d["gridT"]], compat="no_conflicts")
 
     return d

--- a/nemo_cookbook/processing.py
+++ b/nemo_cookbook/processing.py
@@ -14,7 +14,7 @@ import glob
 import numpy as np
 import xarray as xr
 
-from .masks import create_dom_mask, read_dom_mask
+from .masks import create_dom_mask, read_dom_mask, read_dom_maskutil
 
 _DEFAULT_NBGHOST_CHILD = 4
 
@@ -370,8 +370,6 @@ def _add_domain_vars(
             d_grids["gridT"]["e3t"] = domain["e3t_0"]
         d_grids["gridT"]["gphit"] = domain["gphit"]
         d_grids["gridT"]["glamt"] = domain["glamt"]
-        d_grids["gridT"]["top_level"] = domain["top_level"]
-        d_grids["gridT"]["bottom_level"] = domain["bottom_level"]
     except AttributeError as e:
         raise AttributeError(
             "missing required T-grid variable in domain dataset"
@@ -379,6 +377,7 @@ def _add_domain_vars(
 
     if read_mask:
         d_grids["gridT"]["tmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="T")
+        d_grids["gridT"]["tmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="T")
     else:
         d_grids["gridT"]["tmask"] = create_dom_mask(
             ka=ka,
@@ -389,9 +388,9 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-    d_grids["gridT"]["tmaskutil"] = d_grids["gridT"]["tmask"][0, :, :].squeeze(
-        drop=True
-    )
+        d_grids["gridT"]["tmaskutil"] = d_grids["gridT"]["tmask"][0, :, :].squeeze(
+            drop=True
+        )
     d_grids["gridT"] = d_grids["gridT"].assign_attrs(nftype=nftype, iperio=iperio)
 
     # U-grid:
@@ -409,6 +408,7 @@ def _add_domain_vars(
 
     if read_mask:
         d_grids["gridU"]["umask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="U")
+        d_grids["gridU"]["umaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="U")
     else:
         d_grids["gridU"]["umask"] = create_dom_mask(
             ka=ka,
@@ -419,9 +419,9 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-    d_grids["gridU"]["umaskutil"] = d_grids["gridU"]["umask"][0, :, :].squeeze(
-        drop=True
-    )
+        d_grids["gridU"]["umaskutil"] = d_grids["gridU"]["umask"][0, :, :].squeeze(
+            drop=True
+        )
     d_grids["gridU"] = d_grids["gridU"].assign_attrs(nftype=nftype, iperio=iperio)
 
     # V-grid:
@@ -439,6 +439,7 @@ def _add_domain_vars(
 
     if read_mask:
         d_grids["gridV"]["vmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="V")
+        d_grids["gridV"]["vmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="V")
     else:
         d_grids["gridV"]["vmask"] = create_dom_mask(
             ka=ka,
@@ -449,9 +450,9 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-    d_grids["gridV"]["vmaskutil"] = d_grids["gridV"]["vmask"][0, :, :].squeeze(
-        drop=True
-    )
+        d_grids["gridV"]["vmaskutil"] = d_grids["gridV"]["vmask"][0, :, :].squeeze(
+            drop=True
+        )
     d_grids["gridV"] = d_grids["gridV"].assign_attrs(nftype=nftype, iperio=iperio)
 
     # W-grid:
@@ -469,6 +470,8 @@ def _add_domain_vars(
 
     if read_mask:
         d_grids["gridW"]["wmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="W")
+        # W-grid is horizontally co-located with T-grid -> use tmaskutil:
+        d_grids["gridW"]["wmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="T")
     else:
         d_grids["gridW"]["wmask"] = create_dom_mask(
             ka=ka,
@@ -479,9 +482,9 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-    d_grids["gridW"]["wmaskutil"] = d_grids["gridW"]["wmask"][0, :, :].squeeze(
-        drop=True
-    )
+        d_grids["gridW"]["wmaskutil"] = d_grids["gridW"]["wmask"][0, :, :].squeeze(
+            drop=True
+        )
     d_grids["gridW"] = d_grids["gridW"].assign_attrs(nftype=nftype, iperio=iperio)
 
     # F-grid:
@@ -500,6 +503,7 @@ def _add_domain_vars(
 
     if read_mask:
         d_grids["gridF"]["fmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="F")
+        d_grids["gridF"]["fmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="F")
     else:
         d_grids["gridF"]["fmask"] = create_dom_mask(
             ka=ka,
@@ -510,9 +514,9 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-    d_grids["gridF"]["fmaskutil"] = d_grids["gridF"]["fmask"][0, :, :].squeeze(
-        drop=True
-    )
+        d_grids["gridF"]["fmaskutil"] = d_grids["gridF"]["fmask"][0, :, :].squeeze(
+            drop=True
+        )
     d_grids["gridF"] = d_grids["gridF"].assign_attrs(nftype=nftype, iperio=iperio)
 
     return d_grids

--- a/nemo_cookbook/utils.py
+++ b/nemo_cookbook/utils.py
@@ -17,7 +17,7 @@ from typing import Callable
 def deprecated(
     version_since: str,
     version_removed : str,
-    alternative : str = None
+    alternative : str | None = None
     ) -> Callable:
     """
     Utility function to issue a deprecation warning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "dask>=2025.7.0",
   "flox>=0.10.6",
   "fsspec>=2025.3.2",
-  "gsw>=3.6.20",
   "matplotlib",
   "numbagg>=0.8",
   "numba>=0.62",
@@ -43,7 +42,7 @@ dependencies = [
 
 complete = ["nemo_cookbook[parallel,interactive]"]
 parallel = ["dask[complete]"]
-interactive = ["jupyter>=1.1.1", "notebook>=7.4.1", "ipykernel>=6.29.5", "pyarrow>=21.0.0", "cartopy>=0.23", "nc-time-axis"]
+interactive = ["jupyter>=1.1.1", "notebook>=7.4.1", "ipykernel>=6.29.5", "pyarrow>=21.0.0", "cartopy>=0.23", "nc-time-axis", "gsw>=3.6.20",]
 tests = ["pytest", "pytest-mock"]
 docs = ["mkdocs-material", "mkdocs-glightbox", "mkdocs-jupyter", "mkdocstrings", "mkdocstrings-python"]
 
@@ -60,6 +59,9 @@ include = ["nemo_cookbook*"]
 
 [tool.setuptools.package-data]
 nemo_cookbook = ["registry.txt"]
+
+[tool.setuptools_scm]
+fallback_version = "9999"
 
 [tool.ruff]
 line-length = 88

--- a/tests/test_nemodataarray.py
+++ b/tests/test_nemodataarray.py
@@ -63,7 +63,7 @@ class TestNEMODataArrayInit:
         with pytest.raises(KeyError, match=re.escape("gridX not found in available NEMODataTree grids")):
             NEMODataArray(da=da, tree=nemo, grid="gridX")
 
-    def test_da_name_error(self, example_global_nemodatatree):
+    def test_da_dims_name_error(self, example_global_nemodatatree):
         nemo = example_global_nemodatatree
         # DataArray with dimensions not found in NEMO model grid:
         da_error = xr.DataArray(
@@ -77,16 +77,17 @@ class TestNEMODataArrayInit:
         nemo = example_global_nemodatatree
         # DataArray with dimension sizes exceeding NEMO model grid:
         da_error = nemo["gridT"]["tos_con"].copy()
-        da_error['j'] = np.arange(5, 15, dtype=int)
-        with pytest.raises(ValueError, match=re.escape("not all within NEMO model 'gridT' dimension values")):
+        da_error = da_error.pad(pad_width={"i": (0, 5)})
+        with pytest.raises(ValueError, match=re.escape("not all less than or equal to NEMO model 'gridT' dimension sizes")):
             NEMODataArray(da=da_error, tree=nemo, grid="gridT")
 
-    def test_da_dim_values_error(self, example_global_nemodatatree):
+    def test_da_coords_name_error(self, example_global_nemodatatree):
         nemo = example_global_nemodatatree
+        # DataArray with coordinates not found in NEMO model grid:
         da_error = nemo["gridT"]["tos_con"].copy()
-        da_error = da_error.assign_coords(gphit=da_error["gphit"] + 100)
-        # DataArray with coordinate values outside of NEMO model grid coordinates:
-        with pytest.raises(ValueError, match=re.escape("not all within NEMO model 'gridT' coordinate values")):
+        da_error = da_error.assign_coords(glam=(["j", "i"], np.ones((10, 10))))
+
+        with pytest.raises(ValueError, match=re.escape("not all in NEMO model 'gridT' coordinates")):
             NEMODataArray(da=da_error, tree=nemo, grid="gridT")
 
     @pytest.mark.parametrize("dom_type", ["global", "regional"])

--- a/tests/test_nemodatarray_core.py
+++ b/tests/test_nemodatarray_core.py
@@ -129,6 +129,23 @@ class TestNEMODataArrayWeightedMean:
         with pytest.raises(TypeError, match=re.escape("skipna must be specified as a boolean or None.")):
             nda.weighted_mean(dims=["j"], skipna=skipna_error)
 
+    @pytest.mark.parametrize("mask_error", ["mask", np.array([]), [1,0,1]])
+    def test_mask_type_error(self, mask_error, example_global_nemodatatree):
+        nemo = example_global_nemodatatree
+        nda = nemo["gridT/tos_con"]
+        with pytest.raises(TypeError, match=re.escape("mask must be an xarray.DataArray.")):
+            nda.weighted_mean(dims=["j"], mask=mask_error)
+
+    @pytest.mark.parametrize("dom_type", ["global", "regional"])
+    def test_mask_dim_error(
+        self, dom_type, example_global_nemodatatree, example_regional_nemodatatree
+    ):
+        nemo = _get_nemodatatree(dom_type, example_global_nemodatatree, example_regional_nemodatatree)
+        nda = nemo["gridT/tos_con"]
+        mask = xr.DataArray(np.ones((10, 10)), dims=["j", "x"])
+        with pytest.raises(ValueError, match=re.escape("mask must have dimensions subset from")):
+            nda.weighted_mean(dims=["i"], mask=mask)
+
     @pytest.mark.parametrize("dom_type", ["global", "regional"])
     def test_weighted_mean_returns_nemodataarray(
         self, dom_type, example_global_nemodatatree, example_regional_nemodatatree

--- a/tests/test_nemodatatree_core.py
+++ b/tests/test_nemodatatree_core.py
@@ -91,12 +91,18 @@ class TestCellArea():
             )
         areacello = nemo.cell_area(grid=grid, dim='i')
 
+        assert areacello.name == "areacello"
+        assert areacello.equals(data)
+
         # -- Meridional grid cell face area -- #
         data = (
             nemo[grid][f"e3{grid_suffix}"].where(nemo[grid][f"{grid_suffix}mask"])
             * nemo[grid][f"e1{grid_suffix}"].where(nemo[grid][f"{grid_suffix}maskutil"])
             )
         areacello = nemo.cell_area(grid=grid, dim='j')
+
+        assert areacello.name == "areacello"
+        assert areacello.equals(data)
 
         # -- Horizontal grid cell area -- #
         data = (
@@ -105,7 +111,6 @@ class TestCellArea():
             )
         areacello = nemo.cell_area(grid=grid, dim='k')
 
-        # -- Verify equal dims, coords and data values -- #
         assert areacello.name == "areacello"
         assert areacello.equals(data)
 

--- a/tests/test_nemodatatree_core.py
+++ b/tests/test_nemodatatree_core.py
@@ -9,60 +9,12 @@ fixtures from conftest.py.
 Author:
 Ollie Tooth (oliver.tooth@noc.ac.uk)
 """
+import re
+
+import numpy as np
 import pytest
+import xarray as xr
 
-
-class TestVariableMasking():
-    @pytest.mark.parametrize("dom_type", ["global", "regional"])
-    def test_grid_error(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
-        # -- Select NEMODataTree based on domain type -- #
-        match dom_type:
-            case "regional":
-                nemo = example_regional_nemodatatree
-            case "global":
-                nemo = example_global_nemodatatree
-            case _:
-                raise ValueError("dom_type must be 'global' or 'regional'")
-
-        # -- Verify KeyError is raised for non-existent grid -- #
-        with pytest.raises(KeyError, match="/gridT not found in available NEMODataTree grids"):
-            nemo['/gridT/tos_con']
-
-    @pytest.mark.parametrize("dom_type", ["global", "regional"])
-    def test_global_mask_2D_var(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
-        # -- Select NEMODataTree based on domain type -- #
-        match dom_type:
-            case "regional":
-                nemo = example_regional_nemodatatree
-            case "global":
-                nemo = example_global_nemodatatree
-            case _:
-                raise ValueError("dom_type must be 'global' or 'regional'")
-
-        # -- Verify equal dims, coords and data values -- #
-        assert (nemo['gridT/tos_con']
-                .equals(
-                    nemo['gridT']['tos_con'].where(nemo['gridT']['tmaskutil'])
-                    )
-                )
-
-    @pytest.mark.parametrize("dom_type", ["global", "regional"])
-    def test_global_mask_3D_var(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
-        # -- Select NEMODataTree based on domain type -- #
-        match dom_type:
-            case "regional":
-                nemo = example_regional_nemodatatree
-            case "global":
-                nemo = example_global_nemodatatree
-            case _:
-                raise ValueError("dom_type must be 'global' or 'regional'")
-
-        # -- Verify equal dims, coords and data values -- #
-        assert (nemo['gridT/thetao_con']
-                .equals(
-                    nemo['gridT']['thetao_con'].where(nemo['gridT']['tmask'])
-                    )
-                )
 
 class TestCellArea():
     @pytest.mark.parametrize(
@@ -146,35 +98,204 @@ class TestCellVolume():
         assert volcello.name == "volcello"
         assert volcello.equals(data)
 
-class TestDepthIntegral():
-    @pytest.mark.parametrize("limits", [[0, 100], "0, 100", {"lower": 0, "upper": 100}])
-    def test_limits_type(self, limits, example_global_nemodatatree):
-        # -- Verify TypeError is raised for invalid limit type -- #
-        with pytest.raises(TypeError, match="depth limits of integration should be given by a tuple"):
-            example_global_nemodatatree.depth_integral(grid="gridT", var="thetao_con", limits=limits)
-
-    def test_limits_size(self, example_global_nemodatatree):
-        # -- Verify TypeError is raised for invalid limit size -- #
-        with pytest.raises(TypeError, match="depth limits of integration should be given by a tuple"):
-            example_global_nemodatatree.depth_integral(grid="gridT", var="thetao_con", limits=(0, 100, 100))
-
-    @pytest.mark.parametrize("limits", [(-1, 5), (0, -1), (-5, -1)])
-    def test_limits_value(self, limits, example_global_nemodatatree):
-        # -- Verify ValueError is raised for negative limits -- #
-        with pytest.raises(ValueError, match="depth limits of integration must be non-negative"):
-            example_global_nemodatatree.depth_integral(grid="gridT", var='thetao_con', limits=limits)
-
-    def test_limits_order(self, example_global_nemodatatree):
-        # -- Verify ValueError is raised for lower limit >= upper limit -- #
-        with pytest.raises(ValueError, match="lower depth limit must be less than upper depth limit"):
-            example_global_nemodatatree.depth_integral(grid="gridT", var='thetao_con', limits=(5, 2))
+class TestClipGrid():
+    @pytest.mark.parametrize("bbox", [[0, 1, 0, 2], (0, 1), "0 1 2 3"])
+    def test_bbox_type(self, bbox, example_global_nemodatatree):
+        # -- Verify ValueError is raised for invalid bbox -- #
+        with pytest.raises(ValueError, match=re.escape("bounding box must be a tuple (lon_min, lon_max, lat_min, lat_max).")):
+            example_global_nemodatatree.clip_grid(grid="gridT", bbox=bbox)
 
     @pytest.mark.parametrize(
-            "dom_type, limits",
-            [("global", (0, 100)), ("regional", (0, 100)),
-             ("global", (25, 125)), ("regional", (25, 125))
+            "dom_type, grid",
+            [("global", "gridT"), ("regional", "gridT"), ("global", "gridU"), ("regional", "gridU"),
+             ("global", "gridV"), ("regional", "gridV"), ("global", "gridW"), ("regional", "gridW"),
+             ("global", "gridF"), ("regional", "gridF")
              ])
-    def test_depth_integral(self, dom_type, limits, example_global_nemodatatree, example_regional_nemodatatree):
+    def test_clip_grid(self, dom_type, grid, example_global_nemodatatree, example_regional_nemodatatree):
+        # -- Select NEMODataTree based on domain type -- #
+        match dom_type:
+            case "regional":
+                nemo = example_regional_nemodatatree
+                bbox = (40, 62, -50, -32)
+            case "global":
+                nemo = example_global_nemodatatree
+                bbox = (-45, 60, -25, 30)
+            case _:
+                raise ValueError("dom_type must be 'global' or 'regional'")
+
+        grid_suffix = grid[-1].lower()
+        hgrid_type = grid_suffix if "w" not in grid_suffix else "t"
+
+        # -- Clip NEMO model grid -- #
+        nemo_clipped = nemo.clip_grid(grid=grid, bbox=bbox)
+
+        # -- Validate Clipped NEMODataTree -- #
+        # Expect NEMODataTree is returned:
+        assert isinstance(nemo_clipped, type(nemo))
+        # Expect all NEMO model grid nodes are retained:
+        assert nemo_clipped.groups == nemo.groups
+
+        # Expect clipped grid dims sizes to be <= original NEMO model grid:
+        assert nemo_clipped[grid].sizes["i"] <= nemo[grid].sizes["i"]
+        assert nemo_clipped[grid].sizes["j"] <= nemo[grid].sizes["j"]
+
+        # Expect all grid coordinates to be within bounding box:
+        assert nemo_clipped[grid][f"glam{hgrid_type}"].min() >= bbox[0]
+        assert nemo_clipped[grid][f"glam{hgrid_type}"].max() <= bbox[1]
+        assert nemo_clipped[grid][f"gphi{hgrid_type}"].min() >= bbox[2]
+        assert nemo_clipped[grid][f"gphi{hgrid_type}"].max() <= bbox[3]
+
+class TestClipDomain():
+    @pytest.mark.parametrize("bbox", [[0, 1, 0, 2], (0, 1), "0 1 2 3"])
+    def test_bbox_type(self, bbox, example_global_nemodatatree):
+        # -- Verify ValueError is raised for invalid bbox -- #
+        with pytest.raises(ValueError, match=re.escape("bounding box must be a tuple (lon_min, lon_max, lat_min, lat_max).")):
+            example_global_nemodatatree.clip_grid(grid="gridT", bbox=bbox)
+
+    @pytest.mark.parametrize("dom_type", ["global", "regional"])
+    def test_clip_domain(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
+        # -- Select NEMODataTree based on domain type -- #
+        match dom_type:
+            case "regional":
+                nemo = example_regional_nemodatatree
+                bbox = (40, 62, -50, -32)
+            case "global":
+                nemo = example_global_nemodatatree
+                bbox = (-45, 60, -25, 30)
+            case _:
+                raise ValueError("dom_type must be 'global' or 'regional'")
+
+        # -- Clip NEMO model domain -- #
+        nemo_clipped = nemo.clip_domain(dom='.', bbox=bbox)
+
+        # -- Validate Clipped NEMODataTree -- #
+        # Expect NEMODataTree is returned:
+        assert isinstance(nemo_clipped, type(nemo))
+        # Expect all NEMO model grid nodes are retained:
+        assert nemo_clipped.groups == nemo.groups
+
+        # Expect all T-grid coordinates to be within bounding box:
+        assert nemo_clipped["gridT"]["glamt"].min() >= bbox[0]
+        assert nemo_clipped["gridT"]["glamt"].max() <= bbox[1]
+        assert nemo_clipped["gridT"]["gphit"].min() >= bbox[2]
+        assert nemo_clipped["gridT"]["gphit"].max() <= bbox[3]
+
+        grids = ["gridT", "gridU", "gridV", "gridW", "gridF"]
+        # Expect clipped grid dims sizes to be <= original NEMO model grid:
+        assert all(nemo_clipped[grid].sizes["i"] <= nemo[grid].sizes["i"] for grid in grids)
+        assert all(nemo_clipped[grid].sizes["j"] <= nemo[grid].sizes["j"] for grid in grids)
+    
+        # Expect clipped grid dims sizes to be consistent across all grids:
+        assert len(set([nemo_clipped[grid].sizes["i"] for grid in grids])) == 1
+        assert len(set([nemo_clipped[grid].sizes["j"] for grid in grids])) == 1
+
+    @pytest.mark.parametrize("dom_type", ["global", "regional"])
+    def test_clip_domain_sizes(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
+        # -- Select NEMODataTree based on domain type -- #
+        match dom_type:
+            case "regional":
+                nemo = example_regional_nemodatatree
+                bbox = (40, 62, -50, -32)
+            case "global":
+                nemo = example_global_nemodatatree
+                bbox = (-45, 60, -25, 30)
+            case _:
+                raise ValueError("dom_type must be 'global' or 'regional'")
+
+        # -- Clip NEMO model domain -- #
+        nemo_clipped = nemo.clip_domain(dom='.', bbox=bbox)
+
+        # -- Validate Clipped NEMODataTree -- #
+        grids = ["gridT", "gridU", "gridV", "gridW", "gridF"]
+        # Expect clipped grid dims sizes to be consistent across all grids:
+        assert len(set([nemo_clipped[grid].sizes["i"] for grid in grids])) == 1
+        assert len(set([nemo_clipped[grid].sizes["j"] for grid in grids])) == 1
+
+class TestExtractSection():
+    @pytest.mark.parametrize("lon_section", [[0, 1, 0], "glamt"])
+    def test_lon_type(self, lon_section, example_global_nemodatatree):
+        # -- Verify TypeError is raised for invalid lon_section type -- #
+        with pytest.raises(TypeError, match="lon_section must be a numpy array."):
+            example_global_nemodatatree.extract_section(lon_section=lon_section, lat_section=np.array([0, 1]), uv_vars=["uo", "vo"], vars=None, dom=".")
+
+    @pytest.mark.parametrize("lat_section", [[0, 1, 0], "gphit"])
+    def test_lat_type(self, lat_section, example_global_nemodatatree):
+        # -- Verify TypeError is raised for invalid lat_section type -- #
+        with pytest.raises(TypeError, match="lat_section must be a numpy array."):
+            example_global_nemodatatree.extract_section(lon_section=np.array([0, 1]), lat_section=lat_section, uv_vars=["uo", "vo"], vars=None, dom=".")
+
+    @pytest.mark.parametrize("uv_vars", [{"u": "uo", "v": "vo"}, "uo, vo", ["uo", "vo", "wo"]])
+    def test_uv_vars_values(self, uv_vars, example_global_nemodatatree):
+        # -- Verify TypeError is raised for invalid uv_vars type -- #
+        with pytest.raises(TypeError, match=re.escape("uv_vars must be a list of velocity variables to extract (e.g., ['uo', 'vo']).")):
+            example_global_nemodatatree.extract_section(lon_section=np.array([0, 1]), lat_section=np.array([0, 1]), uv_vars=uv_vars, vars=None, dom=".")
+
+    def test_extract_section(self, example_global_nemodatatree):
+        # -- Define NEMODataTree based on domain type -- #
+        nemo = example_global_nemodatatree
+
+        # -- Defining idealised section endpoints -- #
+        lon_section = np.array([-50, 50])
+        lat_section = np.array([-20, 40])
+        
+        # -- Extract mask boundary -- #
+        ds_bdy = nemo.extract_section(lon_section=lon_section,
+                                      lat_section=lat_section,
+                                      uv_vars=["uo", "vo"],
+                                      vars=["thetao_con"],
+                                      dom="."
+                                      )
+
+        # -- Verify section properties -- #
+        # Expect section to have 6 grid cell faces:
+        assert ds_bdy['bdy'].size == 6
+        # Expected section coordinates:
+        for coord in ["gphib", "glamb", "depthb"]:
+            assert coord in ds_bdy.coords
+
+        # -- Verify section grid cell faces -- #
+        expected_flux_types = ["U", "V", "U", "V", "U", "V"]
+        assert ds_bdy['flux_type'].values.tolist() == expected_flux_types
+        # Flux direction is defined as positive for northward/eastward fluxes:
+        expected_flux_dir = [-1, 1, -1, 1, -1, 1]
+        assert ds_bdy['flux_dir'].values.tolist() == expected_flux_dir
+
+        # -- Verify section variables -- #
+        # Expected section variables:
+        for var in ["i_bdy", "j_bdy", "e1b", "e3b", "bmask"]:
+             assert var in ds_bdy.data_vars
+
+        # Expected velocity variable:
+        assert "velocity" in ds_bdy.data_vars
+        assert ds_bdy['velocity'].dims == ("time_counter", "k", "bdy")
+        # Expected tracer variable:
+        assert "thetao_con" in ds_bdy.data_vars
+        assert ds_bdy['thetao_con'].dims == ("time_counter", "k", "bdy")
+
+class TestExtractMaskBoundary():
+    @pytest.mark.parametrize("mask", [[0, 1, 0], "mask_name"])
+    def test_mask_type(self, mask, example_global_nemodatatree):
+        # -- Verify TypeError is raised for invalid mask type -- #
+        with pytest.raises(TypeError, match="mask must be an xarray DataArray"):
+            example_global_nemodatatree.extract_mask_boundary(mask=mask, uv_vars=["uo", "vo"], vars=None, dom=".")
+
+    def test_mask_dims(self, example_global_nemodatatree):
+        # -- Verify ValueError is raised for invalid mask dimensions -- #
+        nemo = example_global_nemodatatree
+        mask = np.zeros((10, 10), dtype=bool)
+        mask[4:6, 4:6] = True
+        da_mask = xr.DataArray(mask, dims=["y", "x"])
+        with pytest.raises(ValueError, match=re.escape("mask must have dimensions 'i' and 'j'")):
+            nemo.extract_mask_boundary(mask=da_mask, uv_vars=["uo", "vo"], vars=None, dom=".")
+
+    @pytest.mark.parametrize("uv_vars", [{"u": "uo", "v": "vo"}, "uo, vo", ["uo", "vo", "wo"]])
+    def test_uv_vars_values(self, uv_vars, example_global_nemodatatree):
+        # -- Verify TypeError is raised for invalid uv_vars type -- #
+        with pytest.raises(TypeError, match=re.escape("uv_vars must be a list of velocity variables to extract (e.g., ['uo', 'vo']).")):
+            example_global_nemodatatree.extract_mask_boundary(mask=xr.DataArray(), uv_vars=uv_vars, vars=None, dom=".")
+
+    @pytest.mark.parametrize("dom_type", ["global", "regional"])
+    def test_extract_mask_boundary(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
         # -- Select NEMODataTree based on domain type -- #
         match dom_type:
             case "regional":
@@ -184,15 +305,42 @@ class TestDepthIntegral():
             case _:
                 raise ValueError("dom_type must be 'global' or 'regional'")
 
-        # -- Depth integration -- #
-        data = (nemo['gridT/thetao_con']
-                .isel(k=0)
-                .drop_vars(['k', 'deptht'])
-                )
-        data = (limits[1] - limits[0]) * data
+        # -- Defining idealised mask -- #
+        # Define 2x2 square mask at the domain centre:
+        mask = np.zeros((10, 10), dtype=bool)
+        mask[4:6, 4:6] = True
+        da_mask = xr.DataArray(mask,
+                               dims=["j", "i"],
+                               coords={"j": nemo["gridT"]["j"], "i": nemo["gridT"]["i"]}
+                               )
+        
+        # -- Extract mask boundary -- #
+        ds_bdy = nemo.extract_mask_boundary(mask=da_mask,
+                                            uv_vars=["uo", "vo"],
+                                            vars=["thetao_con"],
+                                            dom="."
+                                            )
 
-        integral = nemo.depth_integral(grid='gridT', var='thetao_con', limits=limits)
+        # -- Verify boundary properties -- #
+        # Expect boundary to have 8 grid cell faces:
+        assert ds_bdy['bdy'].size == 8
+        # Expected boundary coordinates:
+        for coord in ["gphib", "glamb", "depthb"]:
+            assert coord in ds_bdy.coords
+        # Expected boundary variables:
+        for var in ["i_bdy", "j_bdy", "e1b", "e3b", "bmask"]:
+             assert var in ds_bdy.data_vars
 
-        # -- Verify equal dims, coords and data values -- #
-        assert integral.name == "integral_z(thetao_con)"
-        assert integral.equals(data)
+        # -- Verify boundary grid cell faces -- #
+        expected_flux_types = ["U", "U", "V", "V", "U", "U", "V", "V"]
+        assert ds_bdy['flux_type'].values.tolist() == expected_flux_types
+        # Flux direction is defined as the outward normal:
+        expected_flux_dir = [1, 1, -1, -1, -1, -1, 1, 1]
+        assert ds_bdy['flux_dir'].values.tolist() == expected_flux_dir
+
+        # Expected velocity variable:
+        assert "velocity" in ds_bdy.data_vars
+        assert ds_bdy['velocity'].dims == ("time_counter", "k", "bdy")
+        # Expected tracer variable:
+        assert "thetao_con" in ds_bdy.data_vars
+        assert ds_bdy['thetao_con'].dims == ("time_counter", "k", "bdy")


### PR DESCRIPTION
## Improve Performance of NEMODataArray & NEMODataTree methods

- [x] Remove duplicated masking in computation of derived variables, including masking of grid scale factors.
- [x] Remove unnecessary creation of intermediate NEMODataArrays during the computation of derived variables.
- [x] Remove explicit values comparison from NEMODataArray `__init__` validation in favour of size & dimension checks.
- [x] Refactor `extract_mask_boundary` to use utility functions in `extract.py` module.
- [x] Fix naming convention for along-boundary geographical coordinates to support extracting boundaries / sections from nested NEMO model domains.
- [x] Update `_add_domain_vars` utility function in NEMODataTree constructors to read `{}maskutil` variables directly from the `domain_cfg` dataset when `read_mask=True`.

### Relevant Modules:
* `nemo_cookbook/processing.py`
* `nemo_cookbook/masks.py`
* `nemo_cookbook/extract.py`
* `nemo_cookbook/nemodatatree.py`
* `nemo_cookbook/nemodataarray.py`
* `tests/test_nemodataarray.py`
* `tests/test_nemodatatree_core.py`