### PR TITLE
19 add marimo notebook support for recipes

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1,5 +1,20 @@
 # Summary
 
+**Welcome to the NEMO Cookbook Recipe page :wave:**
+
+Each recipe uses the `NEMODataTree` and `NEMODataArray` data structures and their associated methods to calculate a diagnostic using NEMO ocean model outputs.
+
+Just like the [**Cosima Cookook**](https://cosima-recipes.readthedocs.io/en/latest/), each recipe is a self-contained and internally documented Jupyter notebook. 
+
+There are several ways to explore our available Recipes:
+
+1. Open a static version of the recipe in your browser by selecting **View in Docs**.
+2. Open the recipe in preview mode as a cloud-hosted marimo notebook using **Open in molab**.
+    > You can also fork your Recipes and edit it iteractively in the browser using [**molab**](https://molab.marimo.io/notebooks)!
+3. Open the recipe as an interactive cloud hosted Jupyter notebook using **Open In Colab**.
+    > Note that using [**Google Colab**](https://colab.research.google.com) requires you to pip install nemo_cookbook and its dependencies at the start of your notebook!
+4. Clone the [**NEMO Cookbook**](https://github.com/NOC-MSM/nemo_cookbook) GitHub repository and run the Jupyter notebooks directly from the `recipes/` directory yourself.
+
 ### :book: Available Recipes
 ---
 
@@ -11,7 +26,9 @@
 
     Meridional overturning stream function in an arbitrary tracer coordinates.
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_moc_tracer/)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_moc_tracer/)
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_moc_tracer.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_moc_tracer.ipynb)
 
 -   __Meridional Overturning - Vertical__
 
@@ -19,7 +36,9 @@
 
     Meridional overturning stream function in vertical coordinates (z/z*).
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_moc_z/)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_moc_z/) 
+    
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_moc_z.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_moc_z.ipynb)
 
 -   __Ocean Heat Transport__
 
@@ -27,7 +46,9 @@
 
     Global meridional ocean heat transport.
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_heat_transport/)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_heat_transport/)
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_heat_transport.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_heat_transport.ipynb)
 
 -   __Volume Census__
 
@@ -35,7 +56,9 @@
 
     Seawater volume census in discrete temperature - salinity coordinates.
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_volume_census)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_volume_census)
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_volume_census.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_volume_census.ipynb)
 
 -   __Water Mass Transformation__
 
@@ -43,7 +66,9 @@
 
     Surface-forced water mass transformation in discrete potential density coordinates.
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_sfwmt_sigma0)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_sfwmt_sigma0)
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_sfwmt_sigma0.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_sfwmt_sigma0.ipynb)
 
 -   __Masked Statistics__
 
@@ -51,7 +76,9 @@
 
     Grid-aware masked statistics using bounding boxes and geographical polyons.
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_masked_stats)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_masked_stats)
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_masked_stats.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_masked_stats.ipynb)
 
 -   __Barotropic Stream Function__
 
@@ -59,7 +86,9 @@
 
     Regional barotropic stream functions using grid-aware integration.
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_barotropic_sf)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_barotropic_sf)
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_barotropic_sf.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_barotropic_sf.ipynb)
 
 -   __Ocean Heat Content__
 
@@ -67,7 +96,9 @@
 
     Upper ocean heat content using depth integration.
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_heat_content/)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_heat_content/)
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_heat_content.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_heat_content.ipynb)
 
 -   __Vertical Coordinate Transformations__
 
@@ -75,7 +106,9 @@
 
     Transforming vertical coordinates using conservative remapping.
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_transform_vertical_coords)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_transform_vertical_coords)
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_transform_vertical_coords.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_transform_vertical_coords.ipynb)
 
 -   __Extracting Hydrographic Sections__
 
@@ -83,7 +116,9 @@
 
     Extracting volume transports and properties along the Overturning in the Subpolar North Atlantic array.
 
-    [:octicons-arrow-right-24: Recipe](https://noc-msm.github.io/nemo_cookbook/recipe_extract_osnap)
+    [:octicons-arrow-right-24: View in Docs](https://noc-msm.github.io/nemo_cookbook/recipe_extract_osnap)
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_extract_osnap.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NOC-MSM/nemo_cookbook/blob/main/recipes/recipe_extract_osnap.ipynb)
 
 </div>
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -75,17 +75,18 @@ nav:
   - User Guide: user_guide.md
   - How To...: howto.md
   - Recipes:
-    - recipes.md
-    - Meridional Overturning - Depth Space: recipe_moc_z.ipynb
-    - Meridional Overturning - Tracer Space: recipe_moc_tracer.ipynb
-    - Ocean Heat Transport: recipe_heat_transport.ipynb
-    - Barotropic Stream Functions: recipe_barotropic_sf.ipynb
-    - Ocean Heat Content: recipe_heat_content.ipynb
-    - Regional Masked Statistics: recipe_masked_stats.ipynb
-    - Volume Census in T-S Space: recipe_volume_census.ipynb
-    - Surface-Forced Water Mass Transformation: recipe_sfwmt_sigma0.ipynb
-    - Extracting Hydrographic Sections: recipe_extract_osnap.ipynb
-    - Vertical Coordinate Transformation: recipe_transform_vertical_coords.ipynb
+    - Summary: recipes.md
+    - Recipe List:
+      - Meridional Overturning - Depth Space: recipe_moc_z.ipynb
+      - Meridional Overturning - Tracer Space: recipe_moc_tracer.ipynb
+      - Ocean Heat Transport: recipe_heat_transport.ipynb
+      - Barotropic Stream Functions: recipe_barotropic_sf.ipynb
+      - Ocean Heat Content: recipe_heat_content.ipynb
+      - Regional Masked Statistics: recipe_masked_stats.ipynb
+      - Volume Census in T-S Space: recipe_volume_census.ipynb
+      - Surface-Forced Water Mass Transformation: recipe_sfwmt_sigma0.ipynb
+      - Extracting Hydrographic Sections: recipe_extract_osnap.ipynb
+      - Vertical Coordinate Transformation: recipe_transform_vertical_coords.ipynb
   - API Reference: reference.md
   - Contributing: contributing.md
   - Release Notes: release_notes.md


### PR DESCRIPTION
## Add Marimo & Google Colab Notebook support for existing NEMO Cookbook Recipes.

- [ ] Add molab badges to run NEMO Cookbook recipes as preview Marimo Notebooks in molab.
- [ ] Add Google Colab badges to run NEMO Cookbook recipes as interactive Jupyter Notebooks.
- [ ] Update NEMO Cookbook recipe guidance and recipe list structure in docs.

### Relevant Modules:
* `docs/docs/mkdocs.yml`
* `docs/recipes.md`