### PR TITLE
17 feature add from icechunk nemodatatree constructor

### DIFF
--- a/nemo_cookbook/nemodataarray.py
+++ b/nemo_cookbook/nemodataarray.py
@@ -27,13 +27,14 @@ if TYPE_CHECKING:
 from nemo_cookbook.integrate import compute_depth_integral
 from nemo_cookbook.interpolate import interpolate_grid
 from nemo_cookbook.transform import transform_vertical_coords
+from nemo_cookbook.validation import validate_nemo_dataarray
 
 _NEMO_DIFF_MAP = {
     # -- NEMO Arakawa C-grid Finite Difference Mapping -- #
     # (input_grid_suffix, diff_dim): (output_grid_suffix, output_hgrid_suffix, output_scale_factor)
     ("T", "i"): ("u", "u", "e1u"),
     ("T", "j"): ("v", "v", "e2v"),
-    ("T", "k"): ("w", "t", "e3w"),
+    ("T", "k"): ("w", "w", "e3w"),
     ("U", "i"): ("t", "t", "e1t"),
     ("U", "j"): ("f", "f", "e2f"),
     ("U", "k"): ("uw", "u", "e3uw"),
@@ -92,26 +93,7 @@ class NEMODataArray:
             self._grid = grid
 
         # -- Validate DataArray compatibility -- #
-        grid_keys = list(dict(self._tree.subtree_with_keys).keys())
-        if self._grid not in grid_keys:
-            raise KeyError(
-                f"{self._grid} not found in available NEMODataTree grids {grid_keys}."
-            )
-
-        # Dimension must exist & sizes must be less than or equal to NEMODataTree dimensions:
-        if not all(dim in list(self._tree[self._grid].dims) for dim in self._da.dims):
-            raise ValueError(f"DataArray dimensions {self._da.dims} not all in NEMO model '{self._grid}' dimensions {self._tree[self._grid].dims}.")
-
-        if not all(self._da.sizes[d] <= self._tree[self._grid].sizes[d] for d in self._da.dims):
-            raise ValueError(f"DataArray dimension sizes {self._da.dims} not all less than or equal to NEMO model '{self._grid}' dimension sizes {self._tree[self._grid].dims}.")
-
-        # Core coordinates (glam, gphi, depth, time_counter) must exist & sizes must be less than or equal to NEMODataTree coordinates:
-        core_coords = [coord for coord in self._da.coords if "glam" in coord or "gphi" in coord or "depth" in coord or "time_counter" in coord]
-        if not all(dim in list(self._tree[self._grid].coords) for dim in core_coords):
-            raise ValueError(f"DataArray coordinates {core_coords} not all in NEMO model '{self._grid}' coordinates {self._tree[self._grid].coords}.")
-
-        if not all(self._da[coord].sizes[d] <= self._tree[self._grid].coords[coord].sizes[d] for coord in core_coords for d in self._da[coord].dims):
-            raise ValueError(f"DataArray coordinate sizes {core_coords} not all less than or equal to NEMO model '{self._grid}' coordinate sizes {self._tree[self._grid].coords}.")
+        validate_nemo_dataarray(da=self._da, grid=self._grid, tree=self._tree)
 
         # -- Assign NEMO domain number, grid path and grid type -- #
         dom, dom_prefix, dom_suffix, grid_suffix = self._tree._get_properties(grid=self._grid, infer_dom=True)

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -152,10 +152,9 @@ class NEMODataTree(xr.DataTree):
 
         Examples
         --------
-        Create a zonally periodic `NEMODataTree` from a dictionary of paths to local netCDF files:
+        Create a zonally periodic `NEMODataTree` with north folding on T-points from a dictionary of paths to local netCDF files:
 
         >>> from nemo_cookbook import NEMODataTree
-
         >>> paths = {"parent": {
         ...          "domain": "/path/to/domain_cfg.nc",
         ...          "gridT": "path/to/*_gridT.nc",
@@ -164,7 +163,6 @@ class NEMODataTree(xr.DataTree):
         ...          "gridW": "path/to/*_gridW.nc",
         ...          "icemod": "path/to/*_icemod.nc",
         ...          }}
-
         >>> nemo = NEMODataTree.from_paths(paths, name="My NEMO model", iperio=True, nftype="T")
 
         Create a regional `NEMODataTree` using a linear free-surface approximation from a dictionary of paths to remote netCDF files:
@@ -309,16 +307,13 @@ class NEMODataTree(xr.DataTree):
 
         Examples
         --------
-        Create a `NEMODataTree` from a dictionary of xarray.Dataset objects:
+        Create a zonally periodic `NEMODataTree` with north folding on T-points from a dictionary of xarray.Dataset objects:
 
         >>> import xarray as xr
         >>> from nemo_cookbook import NEMODataTree
-
         >>> ds_domain = xr.open_zarr("https://some_remote_data/domain_cfg.zarr")
         >>> ds_gridT = xr.open_zarr("https://some_remote_data/my_model_gridT.zarr")
-
         >>> datasets = {"parent": {"domain": ds_domain, "gridT": ds_gridT}}
-
         >>> nemo = NEMODataTree.from_datasets(datasets=datasets, name="My NEMO Model", iperio=True, nftype="T")
 
         Create a regional `NEMODataTree` using a linear free-surface approximation from a dictionary of xarray.Dataset objects:
@@ -398,6 +393,7 @@ class NEMODataTree(xr.DataTree):
         name: str = "NEMO model",
         iperio: bool = False,
         nftype: str | None = None,
+        open_kwargs: dict[str, any] | None = None,
         **session_kwargs: dict[str, any],
     ) -> Self:
         """
@@ -419,7 +415,10 @@ class NEMODataTree(xr.DataTree):
         nftype: str, optional
             Type of north fold lateral boundary condition to apply. Options are 'T' for T-point pivot or 'F' for F-point
 
-        **session_kwargs : dict, optional
+        open_kwargs : dict[str, Any], optional
+            Additional keyword arguments to pass to `xarray.open_datatree`. Default is None.
+
+        **session_kwargs : dict[str, Any], optional
             Additional keyword arguments to pass to Icechunk `repo.readonly_session`.
 
         Returns
@@ -429,18 +428,18 @@ class NEMODataTree(xr.DataTree):
 
         Examples
         --------
-        Create a `NEMODataTree` from the main branch of an Icechunk repository:
+        Create a zonally periodic `NEMODataTree` with north folding on F-points from the main branch of an Icechunk repository:
 
         >>> from nemo_cookbook import NEMODataTree
-        >>> nemo = NEMODataTree.from_icechunk(repo=repo, branch="main")
+        >>> nemo = NEMODataTree.from_icechunk(repo=repo, branch="main", iperio=True, nftype="F")
 
         See Also
         --------
-        from_datasets
+        from_zarr
         """
         # -- Validate Inputs -- #
-        if not isinstance(repo, icechunk.repository.Repository):
-            raise TypeError("`repo` must be an Icechunk repository.")
+        if not hasattr(repo, "readonly_session"):
+            raise TypeError("`repo` must implement readonly_session().")
         if not isinstance(name, str):
             raise TypeError("`name` must be a string.")
         if not isinstance(iperio, bool):
@@ -452,7 +451,79 @@ class NEMODataTree(xr.DataTree):
 
         # -- Create NEMODataTree from Icechunk repository -- #:
         session = repo.readonly_session(**session_kwargs)
-        datatree = xr.open_datatree(session.store, engine="zarr")
+        datatree = xr.open_datatree(session.store, engine="zarr", **(open_kwargs or {}))
+        nemo = super().from_dict(datatree.to_dict())
+
+        # -- Update NEMODataTree properties -- #
+        nemo["/"].attrs.update({"nftype": nftype, "iperio": iperio})
+        nemo.name = name
+
+        # -- Validate NEMO grid node Datasets -- #
+        for key in [grid for grid in nemo.groups if grid.startswith("grid")]:
+            validate_nemo_grid_node(key=key, value=nemo[key])
+
+        return nemo
+
+    @classmethod
+    def from_zarr(
+        cls,
+        store: str,
+        name: str = "NEMO model",
+        iperio: bool = False,
+        nftype: str | None = None,
+        **open_kwargs: dict[str, any],
+    ) -> Self:
+        """
+        Create a NEMODataTree from Zarr store groups storing NEMO model outputs
+        organised into a hierarchy of domains (i.e., 'parent', 'child', 'grandchild').
+
+        Parameters
+        ----------
+        store : str
+            Path to the Zarr store containing NEMO model outputs in hierarchical groups.
+
+        name : str, optional
+            Name of the NEMODataTree. Default is "NEMO model".
+        
+        iperio: bool = False
+            Zonal periodicity of the parent domain. Default is False.
+        
+        nftype: str, optional
+            Type of north fold lateral boundary condition to apply. Options are 'T' for T-point pivot or 'F' for F-point
+
+        **open_kwargs : dict[str, Any], optional
+            Additional keyword arguments to pass to `xarray.open_datatree`.
+
+        Returns
+        -------
+        NEMODataTree
+            Hierarchical DataTree of NEMO model outputs.
+
+        Examples
+        --------
+        Create a zonally periodic `NEMODataTree` with north folding on T-points from a hierarchical Zarr store:
+
+        >>> from nemo_cookbook import NEMODataTree
+        >>> nemo = NEMODataTree.from_zarr(store="path/to/zarr/store", iperio=True, nftype="T")
+
+        See Also
+        --------
+        from_icechunk
+        """
+        # -- Validate Inputs -- #
+        if not isinstance(store, str):
+            raise TypeError("`store` must be a string.")
+        if not isinstance(name, str):
+            raise TypeError("`name` must be a string.")
+        if not isinstance(iperio, bool):
+            raise TypeError("zonal periodicity (`iperio`) of parent domain must be a boolean.")
+        if nftype is not None and nftype not in ("T", "F"):
+            raise ValueError(
+                "north fold type (`nftype`) of parent domain must be 'T' (T-pivot fold), 'F' (F-pivot fold), or None."
+            )
+
+        # -- Create NEMODataTree from Zarr store -- #:
+        datatree = xr.open_datatree(store, engine="zarr", **(open_kwargs or {}))
         nemo = super().from_dict(datatree.to_dict())
 
         # -- Update NEMODataTree properties -- #

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -12,6 +12,7 @@ Ollie Tooth (oliver.tooth@noc.ac.uk)
 
 from typing import Self
 
+import icechunk
 import numpy as np
 import xarray as xr
 from xarray.indexes import NDPointIndex
@@ -31,6 +32,7 @@ from nemo_cookbook.processing import create_datatree_dict
 from nemo_cookbook.stats import compute_binned_statistic
 from nemo_cookbook.transform import transform_vertical_coords
 from nemo_cookbook.utils import deprecated
+from nemo_cookbook.validation import validate_nemo_grid_node
 
 
 class NEMODataTree(xr.DataTree):
@@ -197,7 +199,7 @@ class NEMODataTree(xr.DataTree):
         if not isinstance(open_kwargs, dict):
             raise TypeError("`open_kwargs` must be a dictionary.")
 
-        # Define parent, child, grandchild filepath collections:
+        # -- Define parent, child, grandchild filepath collections -- #
         d_child, d_grandchild = None, None
         if "parent" in paths.keys() and isinstance(paths["parent"], dict):
             for key in paths.keys():
@@ -219,7 +221,7 @@ class NEMODataTree(xr.DataTree):
                 "Invalid `paths` structure. Expected a nested dictionary defining NEMO 'parent', 'child' and 'grandchild' domains."
             )
 
-        # Construct DataTree from parent / child / grandchild domains:
+        # -- Construct DataTree from parent / child / grandchild domains -- #
         d_tree = create_datatree_dict(
             d_parent=d_parent,
             d_child=d_child,
@@ -233,10 +235,10 @@ class NEMODataTree(xr.DataTree):
             open_kwargs=dict(**open_kwargs),
         )
 
-        datatree = super().from_dict(d_tree)
-        datatree.name = name
+        nemo = super().from_dict(d_tree)
+        nemo.name = name
 
-        return datatree
+        return nemo
 
     @classmethod
     def from_datasets(
@@ -349,7 +351,7 @@ class NEMODataTree(xr.DataTree):
                 "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer."
             )
 
-        # Define parent, child, grandchild dataset collections:
+        # -- Define parent, child, grandchild dataset collections -- #
         d_child, d_grandchild = None, None
         if "parent" in datasets.keys() and isinstance(datasets["parent"], dict):
             for key in datasets.keys():
@@ -371,7 +373,7 @@ class NEMODataTree(xr.DataTree):
                 "Invalid `datasets` structure. Expected a nested dictionary defining NEMO 'parent', 'child' and 'grandchild' domains."
             )
 
-        # Construct DataTree from parent / child / grandchild domains:
+        # -- Construct DataTree from parent / child / grandchild domains -- #
         d_tree = create_datatree_dict(
             d_parent=d_parent,
             d_child=d_child,
@@ -384,16 +386,90 @@ class NEMODataTree(xr.DataTree):
             nbghost_child=nbghost_child,
         )
 
-        datatree = super().from_dict(d_tree)
-        datatree.name = name
+        nemo = super().from_dict(d_tree)
+        nemo.name = name
 
-        return datatree
+        return nemo
+
+    @classmethod
+    def from_icechunk(
+        cls,
+        repo: icechunk.repository.Repository,
+        name: str = "NEMO model",
+        iperio: bool = False,
+        nftype: str | None = None,
+        **session_kwargs: dict[str, any],
+    ) -> Self:
+        """
+        Create a NEMODataTree from an Icechunk repository storing NEMO model outputs
+        organised into a hierarchy of domains (i.e., 'parent', 'child', 'grandchild').
+
+        Parameters
+        ----------
+        repo : icechunk.repository.Repository
+            Icechunk repository containing NEMO model outputs organised into a
+            hierarchy of domains.
+
+        name : str, optional
+            Name of the NEMODataTree. Default is "NEMO model".
+        
+        iperio: bool = False
+            Zonal periodicity of the parent domain. Default is False.
+        
+        nftype: str, optional
+            Type of north fold lateral boundary condition to apply. Options are 'T' for T-point pivot or 'F' for F-point
+
+        **session_kwargs : dict, optional
+            Additional keyword arguments to pass to Icechunk `repo.readonly_session`.
+
+        Returns
+        -------
+        NEMODataTree
+            Hierarchical DataTree of NEMO model outputs.
+
+        Examples
+        --------
+        Create a `NEMODataTree` from the main branch of an Icechunk repository:
+
+        >>> from nemo_cookbook import NEMODataTree
+        >>> nemo = NEMODataTree.from_icechunk(repo=repo, branch="main")
+
+        See Also
+        --------
+        from_datasets
+        """
+        # -- Validate Inputs -- #
+        if not isinstance(repo, icechunk.repository.Repository):
+            raise TypeError("`repo` must be an Icechunk repository.")
+        if not isinstance(name, str):
+            raise TypeError("`name` must be a string.")
+        if not isinstance(iperio, bool):
+            raise TypeError("zonal periodicity (`iperio`) of parent domain must be a boolean.")
+        if nftype is not None and nftype not in ("T", "F"):
+            raise ValueError(
+                "north fold type (`nftype`) of parent domain must be 'T' (T-pivot fold), 'F' (F-pivot fold), or None."
+            )
+
+        # -- Create NEMODataTree from Icechunk repository -- #:
+        session = repo.readonly_session(**session_kwargs)
+        datatree = xr.open_datatree(session.store, engine="zarr")
+        nemo = super().from_dict(datatree.to_dict())
+
+        # -- Update NEMODataTree properties -- #
+        nemo["/"].attrs.update({"nftype": nftype, "iperio": iperio})
+        nemo.name = name
+
+        # -- Validate NEMO grid node Datasets -- #
+        for key in [grid for grid in nemo.groups if grid.startswith("grid")]:
+            validate_nemo_grid_node(key=key, value=nemo[key])
+
+        return nemo
     
     def __setitem__(
             self,
             key: str,
             value: NEMODataArray | xr.DataArray | xr.Dataset,
-            validate: bool = True
+            strict: bool = True
         ) -> None:
         """
         Set a child node or variable in this NEMODataTree.
@@ -401,7 +477,7 @@ class NEMODataTree(xr.DataTree):
         Overloads the __setitem__() method of xarray.DataTree to allow
         setting NEMODataArrays via variable paths (i.e, /grid/var).
 
-        Validate option used for testing only.
+        Optionally set strict=False to bypass validation of child grid nodes.
 
         Parameters
         ----------
@@ -413,7 +489,7 @@ class NEMODataTree(xr.DataTree):
             Object to set at the specified key. If a NEMODataArray is provided,
             the underlying xarray.DataArray will be set at the specified key.
 
-        validate : bool, optional
+        strict : bool, optional
             Validate Datasets assigned to NEMO grid nodes to ensure they contain
             the required dimensions and coordinates. Default is True.
 
@@ -425,23 +501,9 @@ class NEMODataTree(xr.DataTree):
         if isinstance(value, NEMODataArray):
             value = value.data
 
-        if validate and isinstance(value, xr.Dataset):
-            # Define suffix NEMO grid node:
-            grid_type = key[-1].lower()
-            hgrid_type = grid_type if "w" not in grid_type else "t"
-
-            # -- Verify coordinates of NEMO grid node dataset -- #
-            if any([coord not in value.coords for coord in ["i", "j"]]):
-                raise ValueError("Missing required NEMO grid coordinates (i, j) in xarray.Dataset.")
-
-            if all([f'gphi{hgrid_type}' not in coord for coord in value.coords]):
-                raise ValueError(f"Missing required latitude (e.g., gphi{hgrid_type}) coordinates in xarray.Dataset.")
-
-            if all([f'glam{hgrid_type}' not in coord for coord in value.coords]):
-                raise ValueError(f"Missing required longitude (e.g., glam{hgrid_type}) coordinates in xarray.Dataset.")
-
-            if all([f'depth{grid_type}' not in coord for coord in value.coords]) and ("k" in value.coords):
-                raise ValueError(f"Missing required depth (e.g., depth{grid_type}) coordinates in xarray.Dataset.")
+        if strict and isinstance(value, xr.Dataset):
+            # -- Validate NEMO grid node Dataset -- #
+            validate_nemo_grid_node(key=key, value=value)
 
         return super().__setitem__(key, value)
 
@@ -1419,12 +1481,11 @@ class NEMODataTree(xr.DataTree):
 
         # -- Get NEMO model grid properties -- #
         _, dom_prefix, _, grid_suffix = self._get_properties(grid=grid, infer_dom=True)
-        hgrid_type = grid_suffix if "w" not in grid_suffix else "t"
 
         # -- Clip the grid to given bounding box -- #
         # Indexing with a mask requires loading coords into memory:
-        glam = self[grid][f"{dom_prefix}glam{hgrid_type}"].load()
-        gphi = self[grid][f"{dom_prefix}gphi{hgrid_type}"].load()
+        glam = self[grid][f"{dom_prefix}glam{grid_suffix}"].load()
+        gphi = self[grid][f"{dom_prefix}gphi{grid_suffix}"].load()
 
         grid_clipped = self[grid].dataset.where(
             (glam >= bbox[0])
@@ -1587,16 +1648,15 @@ class NEMODataTree(xr.DataTree):
 
         # -- Get NEMO model grid properties -- #
         dom, dom_prefix, _, grid_suffix = self._get_properties(grid=grid, infer_dom=True)
-        hgrid_type = grid_suffix if "w" not in grid_suffix else "t"
         ijk_names = self._get_ijk_names(grid=grid)
         i_name, j_name = ijk_names["i"], ijk_names["j"]
 
         if dom == ".":
-            lon_name = f"glam{hgrid_type}"
-            lat_name = f"gphi{hgrid_type}"
+            lon_name = f"glam{grid_suffix}"
+            lat_name = f"gphi{grid_suffix}"
         else:
-            lon_name = f"{dom_prefix}glam{hgrid_type}"
-            lat_name = f"{dom_prefix}gphi{hgrid_type}"
+            lon_name = f"{dom_prefix}glam{grid_suffix}"
+            lat_name = f"{dom_prefix}gphi{grid_suffix}"
 
         # -- Create mask using polygon coordinates -- #
         mask = create_polygon_mask(

--- a/nemo_cookbook/processing.py
+++ b/nemo_cookbook/processing.py
@@ -457,12 +457,12 @@ def _add_domain_vars(
 
     # W-grid:
     try:
-        d_grids["gridW"]["e1t"] = domain["e1t"]
-        d_grids["gridW"]["e2t"] = domain["e2t"]
+        d_grids["gridW"]["e1w"] = domain["e1t"]
+        d_grids["gridW"]["e2w"] = domain["e2t"]
         if key_linssh:
             d_grids["gridW"]["e3w"] = domain["e3w_0"]
-        d_grids["gridW"]["gphit"] = domain["gphit"]
-        d_grids["gridW"]["glamt"] = domain["glamt"]
+        d_grids["gridW"]["gphiw"] = domain["gphit"]
+        d_grids["gridW"]["glamw"] = domain["glamt"]
     except AttributeError as e:
         raise AttributeError(
             "missing required W-grid variable in domain dataset"
@@ -564,8 +564,6 @@ def _process_grid(
     """
     # Define variable names and dimension mappings:
     grid_type = grid[-1].lower()
-    # W-grid is horizontally co-located with T-grid, so use 'glamt' and 'gphit':
-    hgrid_type = grid_type if grid_type in ("t", "u", "v", "f") else "t"
     mask_name = f"{label}{grid_type}mask"
 
     # Rename horizontal dimensions of grid:
@@ -573,8 +571,8 @@ def _process_grid(
 
     # Rename vertical dimension & grid coordinate variables:
     d_vars = {
-        f"gphi{hgrid_type}": f"{label}gphi{hgrid_type}",
-        f"glam{hgrid_type}": f"{label}glam{hgrid_type}",
+        f"gphi{grid_type}": f"{label}gphi{grid_type}",
+        f"glam{grid_type}": f"{label}glam{grid_type}",
     }
     if f"depth{grid_type}" in data.coords:
         data = data.rename_dims({f"depth{grid_type}": k_name})
@@ -613,8 +611,8 @@ def _process_grid(
     d_coords = {
         j_name: data[j_name] + j_offset,
         i_name: data[i_name] + i_offset,
-        f"{label}gphi{hgrid_type}": data[f"{label}gphi{hgrid_type}"],
-        f"{label}glam{hgrid_type}": data[f"{label}glam{hgrid_type}"],
+        f"{label}gphi{grid_type}": data[f"{label}gphi{grid_type}"],
+        f"{label}glam{grid_type}": data[f"{label}glam{grid_type}"],
     }
     if k_name in data.coords:
         d_coords.update({k_name: data[k_name] + k_offset})

--- a/nemo_cookbook/validation.py
+++ b/nemo_cookbook/validation.py
@@ -1,0 +1,117 @@
+"""
+validation.py
+
+Description:
+This module includes validation functions for the core data structures
+used in the NEMO Cookbook library.
+
+
+Author:
+Ollie Tooth (oliver.tooth@noc.ac.uk)
+"""
+import xarray as xr
+
+
+def validate_nemo_grid_node(
+    key: str,
+    value: xr.Dataset,
+    ) -> None:
+    """
+    Validate that an xarray.Dataset to be assigned to a NEMO model grid node
+    contains the required dimensions, coordinates and properties based on the
+    specified grid type.
+
+    Parameters
+    ----------
+    key : str
+        Variable path (e.g., '/gridT', '/gridU/1_gridU') of the NEMO model
+        grid node to validate.
+    value : xr.Dataset
+        NEMO model grid node Dataset to validate.
+     """
+    # -- Collect domain prefix, suffix and grid type -- #
+    key_nums = [char for char in key if char.isdigit()]
+    dom_prefix, dom_suffix = (f"{key_nums[-1]}_", f"{key_nums[-1]}") if len(key_nums) > 0 else ("", "")
+
+    grid_type = key[-1].lower()
+
+    # -- Validate NEMO grid type -- #
+    valid_grid_types = ["t", "u", "v", "w", "f", "uw", "vw", "fw", "b"]
+    if grid_type not in valid_grid_types:
+        raise ValueError(f"Invalid NEMO model grid type. NEMO model grid node type must be one of: {valid_grid_types}.")
+
+    if dom_suffix != "":
+        # -- Validate parent & child NEMO grid types match -- #
+        if len(set([grid[-1] for grid in key.split("/") if grid != ""])) > 1:
+            raise ValueError("Invalid NEMO model grid node. All NEMO model grid nodes within a parent domain must have the same grid type (e.g., T, U, V, W, F).")
+
+    # -- Verify dimensions of NEMO grid node dataset -- #
+    valid_dims = [
+        (f"i{dom_suffix}", f"j{dom_suffix}"),
+        (f"i{dom_suffix}", f"j{dom_suffix}", f"k{dom_suffix}"),
+        (f"i{dom_suffix}", f"j{dom_suffix}", f"k{dom_suffix}", "time_counter"),
+    ]
+    if not any(set(core_dims).issubset(value.dims) for core_dims in valid_dims):
+        raise ValueError(f"Invalid NEMO model grid dimensions. NEMO model grid node must comply with one of the following core dimension sets: {valid_dims}.")
+
+    # -- Verify coordinates of NEMO grid node dataset -- #
+    valid_coords = [
+        (f"i{dom_suffix}", f"j{dom_suffix}", f"{dom_prefix}gphi{grid_type}", f"{dom_prefix}glam{grid_type}"),
+        (f"i{dom_suffix}", f"j{dom_suffix}", f"k{dom_suffix}", f"{dom_prefix}gphi{grid_type}", f"{dom_prefix}glam{grid_type}", f"{dom_prefix}depth{grid_type}"),
+        (f"i{dom_suffix}", f"j{dom_suffix}", f"k{dom_suffix}", "time_counter"),
+    ]
+    if not any(set(core_coords).issubset(value.coords) for core_coords in valid_coords):
+        raise ValueError(f"Invalid NEMO model grid coordinates. NEMO model grid node must comply with one of the following core coordinate sets: {valid_coords}.")
+    
+    # -- Verify properties of NEMO grid node dataset -- #
+    valid_properties = [
+        (f"{grid_type}maskutil", f"{grid_type}mask", f"e1{grid_type}", f"e2{grid_type}", f"e3{grid_type}"),
+        # Accept boundary grid nodes without `e2b` grid scale factor:
+        (f"{grid_type}maskutil", f"{grid_type}mask", f"e1{grid_type}", f"e3{grid_type}"),
+        (f"{grid_type}maskutil", f"e1{grid_type}", f"e2{grid_type}"),
+    ]
+    if not any(set(core_props).issubset(value.data_vars) for core_props in valid_properties):
+        raise ValueError(f"Invalid NEMO model grid properties. NEMO model grid node must comply with one of the following core property sets: {valid_properties}.")
+
+
+def validate_nemo_dataarray(
+        da: xr.DataArray,
+        grid: str,
+        tree: xr.DataTree,
+    ) -> None:
+    """
+    Validate that an xarray.DataArray to be transformed into a NEMODataArray
+    contains the required dimensions, coordinates and properties.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Variable defined on a NEMO model grid.
+    tree: NEMODataTree
+        NEMODataTree to which the variable belongs.
+    grid: str
+        Path to NEMO model grid where variable is defined (e.g., 'gridT').
+     """
+    # -- Verify grid exists in NEMODataTree -- #
+    grid_keys = list(dict(tree.subtree_with_keys).keys())
+    if grid not in grid_keys:
+        raise KeyError(
+            f"{grid} not found in available NEMODataTree grids {grid_keys}."
+        )
+
+    # -- Verify core dimensions exist -- #
+    if not all(dim in list(tree[grid].dims) for dim in da.dims):
+        raise ValueError(f"DataArray dimensions {da.dims} not all in NEMO model '{grid}' dimensions {tree[grid].dims}.")
+
+    # -- Verify core dimension sizes -- #
+    if not all(da.sizes[d] <= tree[grid].sizes[d] for d in da.dims):
+        raise ValueError(f"DataArray dimension sizes {da.dims} not all less than or equal to NEMO model '{grid}' dimension sizes {tree[grid].dims}.")
+
+    # -- Verify core coordinates exist -- #
+    core_coords = [coord for coord in da.coords if "glam" in coord or "gphi" in coord or "depth" in coord or "time_counter" in coord]
+    if not all(dim in list(tree[grid].coords) for dim in core_coords):
+        raise ValueError(f"DataArray coordinates {core_coords} not all in NEMO model '{grid}' coordinates {tree[grid].coords}.")
+
+    # -- Verify core coordinate sizes -- #
+    if not all(da[coord].sizes[d] <= tree[grid].coords[coord].sizes[d] for coord in core_coords for d in da[coord].dims):
+        raise ValueError(f"DataArray coordinate sizes {core_coords} not all less than or equal to NEMO model '{grid}' coordinate sizes {tree[grid].coords}.")

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,7 @@ aiohttp = "*"
 dask = "*"
 flox = "*"
 fsspec = "*"
-gsw = "*"
+icechunk = "*"
 matplotlib = "*"
 numbagg = "*"
 numba = "0.62*"
@@ -63,6 +63,7 @@ ipykernel = ">=7.2.0,<8"
 nc-time-axis = "*"
 notebook = "*"
 pyarrow = "*"
+gsw = "*"
 
 [environments]
 default = { solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "dask>=2025.7.0",
   "flox>=0.10.6",
   "fsspec>=2025.3.2",
+  "icechunk",
   "matplotlib",
   "numbagg>=0.8",
   "numba>=0.62",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def example_global_nemodatatree() -> NEMODataTree:
         'e1t': (("j", "i"), np.ones((nj, ni))),
         'e2t': (("j", "i"), np.ones((nj, ni))),
         'e3t': (e3_dims, e3_data),
+        'tmaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'tmask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridT"] = (ds_gridT
@@ -79,6 +80,7 @@ def example_global_nemodatatree() -> NEMODataTree:
         'e1u': (("j", "i"), np.ones((nj, ni))),
         'e2u': (("j", "i"), np.ones((nj, ni))),
         'e3u': (e3_dims, e3_data),
+        'umaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'umask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridU"] = (ds_gridU
@@ -104,6 +106,7 @@ def example_global_nemodatatree() -> NEMODataTree:
         'e1v': (("j", "i"), np.ones((nj, ni))),
         'e2v': (("j", "i"), np.ones((nj, ni))),
         'e3v': (e3_dims, e3_data),
+        'vmaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'vmask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridV"] = (ds_gridV
@@ -130,6 +133,7 @@ def example_global_nemodatatree() -> NEMODataTree:
         'e1w': (("j", "i"), np.ones((nj, ni))),
         'e2w': (("j", "i"), np.ones((nj, ni))),
         'e3w': (e3_dims, e3_data),
+        'wmaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'wmask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridW"] = (ds_gridW
@@ -137,8 +141,8 @@ def example_global_nemodatatree() -> NEMODataTree:
                                     j=np.arange(1, nj + 1),
                                     k=np.arange(1, nk + 1) - 0.5,
                                     time_counter=time_data,
-                                    gphit=(("j", "i"), gphi[::2, :]),
-                                    glamt=(("j", "i"), glam[:, ::2]),
+                                    gphiw=(("j", "i"), gphi[::2, :]),
+                                    glamw=(("j", "i"), glam[:, ::2]),
                                     depthw=(("k"), np.arange(0, 250, 50))
                                     )
                     )
@@ -155,6 +159,7 @@ def example_global_nemodatatree() -> NEMODataTree:
         'e1f': (("j", "i"), np.ones((nj, ni))),
         'e2f': (("j", "i"), np.ones((nj, ni))),
         'e3f': (e3_dims, e3_data),
+        'fmaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'fmask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridF"] = (ds_gridF
@@ -294,6 +299,7 @@ def example_regional_nemodatatree() -> NEMODataTree:
         'e1t': (("j", "i"), np.ones((nj, ni))),
         'e2t': (("j", "i"), np.ones((nj, ni))),
         'e3t': (e3_dims, e3_data),
+        'tmaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'tmask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridT"] = (ds_gridT
@@ -320,6 +326,7 @@ def example_regional_nemodatatree() -> NEMODataTree:
         'e1u': (("j", "i"), np.ones((nj, ni))),
         'e2u': (("j", "i"), np.ones((nj, ni))),
         'e3u': (e3_dims, e3_data),
+        'umaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'umask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridU"] = (ds_gridU
@@ -346,6 +353,7 @@ def example_regional_nemodatatree() -> NEMODataTree:
         'e1v': (("j", "i"), np.ones((nj, ni))),
         'e2v': (("j", "i"), np.ones((nj, ni))),
         'e3v': (e3_dims, e3_data),
+        'vmaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'vmask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridV"] = (ds_gridV
@@ -373,6 +381,7 @@ def example_regional_nemodatatree() -> NEMODataTree:
         'e1w': (("j", "i"), np.ones((nj, ni))),
         'e2w': (("j", "i"), np.ones((nj, ni))),
         'e3w': (e3_dims, e3_data),
+        'wmaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'wmask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridW"] = (ds_gridW
@@ -380,8 +389,8 @@ def example_regional_nemodatatree() -> NEMODataTree:
                                     j=np.arange(1, nj + 1),
                                     k=np.arange(1, nk + 1) - 0.5,
                                     time_counter=time_data,
-                                    gphit=(("j", "i"), gphi[1::2, :]),
-                                    glamt=(("j", "i"), glam[:, ::2]),
+                                    gphiw=(("j", "i"), gphi[1::2, :]),
+                                    glamw=(("j", "i"), glam[:, ::2]),
                                     depthw=(("k"), np.arange(0, 250, 50))
                                     )
                     )
@@ -400,6 +409,7 @@ def example_regional_nemodatatree() -> NEMODataTree:
         'e2f': (("j", "i"), np.ones((nj, ni))),
         'e3f': (e3_dims, e3_data),
         'depthf': (("k"), np.linspace(0, 500, nk)),
+        'fmaskutil': (("j", "i"), np.ones((nj, ni)).astype(bool)),
         'fmask': (("k", "j", "i"), np.ones((nk, nj, ni)).astype(bool)),
     })
     nemo["gridF"] = (ds_gridF

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -48,10 +48,10 @@ class TestNEMODataTreeExamples():
         nodes = [entry[0] for entry in list(nemo.subtree_with_keys)]
         for node in ['gridT', 'gridU', 'gridV', 'gridW']:
             assert node in nodes
-            grid_suffix = node[-1].lower() if node != "gridW" else "t"
-            for factor in [f"e1{grid_suffix}", f"e2{grid_suffix}", f"e3{node[-1].lower()}"]:
+            grid_suffix = node[-1].lower()
+            for factor in [f"e1{grid_suffix}", f"e2{grid_suffix}", f"e3{grid_suffix}"]:
                 assert factor in nemo[node].data_vars
-            for coord in [f"glam{grid_suffix}", f"gphi{grid_suffix}", f"depth{node[-1].lower()}"]:
+            for coord in [f"glam{grid_suffix}", f"gphi{grid_suffix}", f"depth{grid_suffix}"]:
                 assert coord in nemo[node].coords
 
         # -- Tear down -- #
@@ -67,10 +67,10 @@ class TestNEMODataTreeExamples():
         nodes = [entry[0] for entry in list(nemo.subtree_with_keys)]
         for node in ['gridT', 'gridU', 'gridV', 'gridW']:
             assert node in nodes
-            grid_suffix = node[-1].lower() if node != "gridW" else "t"
-            for factor in [f"e1{grid_suffix}", f"e2{grid_suffix}", f"e3{node[-1].lower()}"]:
+            grid_suffix = node[-1].lower()
+            for factor in [f"e1{grid_suffix}", f"e2{grid_suffix}", f"e3{grid_suffix}"]:
                 assert factor in nemo[node].data_vars
-            for coord in [f"glam{grid_suffix}", f"gphi{grid_suffix}", f"depth{node[-1].lower()}"]:
+            for coord in [f"glam{grid_suffix}", f"gphi{grid_suffix}", f"depth{grid_suffix}"]:
                 assert coord in nemo[node].coords
 
         # -- Tear down -- #

--- a/tests/test_nemodatatree.py
+++ b/tests/test_nemodatatree.py
@@ -222,7 +222,7 @@ class TestNEMODataTreeUtils():
         # -- Create NEMODataTree instance -- #
         nemo = NEMODataTree()
         # Assign grid node without validation:
-        nemo.__setitem__(key='gridT', value=xr.Dataset(), validate=False)
+        nemo.__setitem__(key='gridT', value=xr.Dataset(), strict=False)
         # -- Verify grid properties -- #
         result = nemo._get_properties(grid="gridT", infer_dom=infer_dom)
         if infer_dom:
@@ -238,8 +238,8 @@ class TestNEMODataTreeUtils():
         # -- Create NEMODataTree instance -- #
         nemo = NEMODataTree()
         # Assign grid nodes without validation:
-        nemo.__setitem__(key='gridT', value=xr.Dataset(), validate=False)
-        nemo.__setitem__(key='gridT/1_gridT', value=xr.Dataset(), validate=False)
+        nemo.__setitem__(key='gridT', value=xr.Dataset(), strict=False)
+        nemo.__setitem__(key='gridT/1_gridT', value=xr.Dataset(), strict=False)
         # -- Verify grid node paths -- #
         result = nemo._get_grid_paths(dom=dom)
         assert isinstance(result, dict)
@@ -267,7 +267,7 @@ class TestNEMODataTreeUtils():
         # -- Create NEMODataTree instance -- #
         nemo = NEMODataTree()
         # Assign grid nodes without validation:
-        nemo.__setitem__(key=grid, value=xr.Dataset(), validate=False)
+        nemo.__setitem__(key=grid, value=xr.Dataset(), strict=False)
         # -- Verify ijk names -- #
         result = nemo._get_ijk_names(grid=grid)
         assert isinstance(result, dict)
@@ -282,7 +282,7 @@ class TestNEMODataTreeUtils():
         # -- Create NEMODataTree instance -- #
         nemo = NEMODataTree()
         # Assign grid nodes without validation:
-        nemo.__setitem__(key="gridT", value=xr.Dataset(), validate=False)
+        nemo.__setitem__(key="gridT", value=xr.Dataset(), strict=False)
         # -- Verify ValueError -- #
         expected_str = "dims must be a list containing one or more of the following dimensions: ['i', 'j', 'k']."
         with pytest.raises(ValueError, match=re.escape(expected_str)):
@@ -293,7 +293,7 @@ class TestNEMODataTreeUtils():
         nemo = NEMODataTree()
         grid = "gridT"
         # Assign grid nodes without validation:
-        nemo.__setitem__(key=grid, value=xr.Dataset(), validate=False)
+        nemo.__setitem__(key=grid, value=xr.Dataset(), strict=False)
         # -- Verify KeyError -- #
         dims = ["i"]
         expected_str = f"weights missing for dimensions {dims} of NEMO model grid {grid}"

--- a/tests/test_nemodatatree.py
+++ b/tests/test_nemodatatree.py
@@ -11,6 +11,7 @@ Ollie Tooth (oliver.tooth@noc.ac.uk)
 """
 import re
 
+import icechunk
 import numpy as np
 import pytest
 import xarray as xr
@@ -193,6 +194,91 @@ class TestNEMODataTreeDatasets():
         result = NEMODataTree.from_datasets(datasets=datasets)
         assert isinstance(result, NEMODataTree) & isinstance(result, xr.DataTree)
 
+class TestNEMODataTreeFromIcechunk():
+    def test_repo_errors(self):
+        # -- Verify TypeError -- #
+        expected_str = "`repo` must implement readonly_session()."
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            NEMODataTree.from_icechunk(repo="invalid_repo")
+
+    @pytest.mark.parametrize("name", [["Model"], ("My", "Model"), 123, None])
+    def test_name_errors(self, mocker, name):
+        mock_repo = mocker.MagicMock(spec=icechunk.repository.Repository)
+        # -- Verify TypeError -- #
+        expected_str = "`name` must be a string."
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            NEMODataTree.from_icechunk(repo=mock_repo, name=name)
+
+    @pytest.mark.parametrize("iperio", ["False", 0])
+    def test_iperio_errors(self, mocker, iperio):
+        mock_repo = mocker.MagicMock(spec=icechunk.repository.Repository)
+        # -- Verify TypeError -- #
+        expected_str = "zonal periodicity (`iperio`) of parent domain must be a boolean."
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            NEMODataTree.from_icechunk(repo=mock_repo, iperio=iperio)
+    
+    @pytest.mark.parametrize("nftype", ["invalid", 123])
+    def test_nftype_errors(self, mocker, nftype):
+        mock_repo = mocker.MagicMock(spec=icechunk.repository.Repository)
+        # -- Verify ValueError -- #
+        expected_str = "north fold type (`nftype`) of parent domain must be 'T' (T-pivot fold), 'F' (F-pivot fold), or None."
+        with pytest.raises(ValueError, match=re.escape(expected_str)):
+            NEMODataTree.from_icechunk(repo=mock_repo, nftype=nftype)
+
+    def test_from_icechunk_properties(self, mocker, example_global_nemodatatree):
+        # -- Create mock Icechunk repository and session -- #
+        mock_repo = mocker.MagicMock(spec=icechunk.repository.Repository)
+        mock_session = mocker.MagicMock()
+        mock_session.store = "fake_store"
+        mock_repo.readonly_session.return_value = mock_session
+
+        # -- Mock xarray.open_datatree to return example NEMODataTree -- #
+        mocker.patch("xarray.open_datatree", return_value=example_global_nemodatatree)
+
+        # -- Verify NEMODataTree properties -- #
+        result = NEMODataTree.from_icechunk(repo=mock_repo, name="MyModel", iperio=True, nftype="T")
+        assert result.name == "MyModel"
+        assert result.attrs["iperio"]
+        assert result.attrs["nftype"] == "T"
+
+class TestNEMODataTreeFromZarr():
+    @pytest.mark.parametrize("store", [["store"], ("store",), 123, None])
+    def test_store_errors(self, store):
+        # -- Verify TypeError -- #
+        expected_str = "`store` must be a string."
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            NEMODataTree.from_zarr(store=store)
+
+    @pytest.mark.parametrize("name", [['Model'], ("Model",), 123, None])
+    def test_name_errors(self, name):
+        # -- Verify TypeError -- #
+        expected_str = "`name` must be a string."
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            NEMODataTree.from_zarr(store="path/to/store", name=name)
+
+    @pytest.mark.parametrize("iperio", ["False", 0])
+    def test_iperio_errors(self, iperio):
+        # -- Verify TypeError -- #
+        expected_str = "zonal periodicity (`iperio`) of parent domain must be a boolean."
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            NEMODataTree.from_zarr(store="path/to/store", iperio=iperio)
+    
+    @pytest.mark.parametrize("nftype", ["invalid", 123])
+    def test_nftype_errors(self, nftype):
+        # -- Verify ValueError -- #
+        expected_str = "north fold type (`nftype`) of parent domain must be 'T' (T-pivot fold), 'F' (F-pivot fold), or None."
+        with pytest.raises(ValueError, match=re.escape(expected_str)):
+            NEMODataTree.from_zarr(store="path/to/store", nftype=nftype)
+
+    def test_from_zarr_properties(self, mocker, example_global_nemodatatree):
+        # -- Mock xarray.open_datatree to return example NEMODataTree -- #
+        mocker.patch("xarray.open_datatree", return_value=example_global_nemodatatree)
+
+        # -- Verify NEMODataTree properties -- #
+        result = NEMODataTree.from_zarr(store="path/to/store", name="MyModel", iperio=True, nftype="T")
+        assert result.name == "MyModel"
+        assert result.attrs["iperio"]
+        assert result.attrs["nftype"] == "T"
 
 class TestNEMODataTreeUtils():
     @pytest.mark.parametrize("dom", [".", "1"])

--- a/tests/test_nemodatatree_core.py
+++ b/tests/test_nemodatatree_core.py
@@ -124,7 +124,6 @@ class TestClipGrid():
                 raise ValueError("dom_type must be 'global' or 'regional'")
 
         grid_suffix = grid[-1].lower()
-        hgrid_type = grid_suffix if "w" not in grid_suffix else "t"
 
         # -- Clip NEMO model grid -- #
         nemo_clipped = nemo.clip_grid(grid=grid, bbox=bbox)
@@ -140,10 +139,10 @@ class TestClipGrid():
         assert nemo_clipped[grid].sizes["j"] <= nemo[grid].sizes["j"]
 
         # Expect all grid coordinates to be within bounding box:
-        assert nemo_clipped[grid][f"glam{hgrid_type}"].min() >= bbox[0]
-        assert nemo_clipped[grid][f"glam{hgrid_type}"].max() <= bbox[1]
-        assert nemo_clipped[grid][f"gphi{hgrid_type}"].min() >= bbox[2]
-        assert nemo_clipped[grid][f"gphi{hgrid_type}"].max() <= bbox[3]
+        assert nemo_clipped[grid][f"glam{grid_suffix}"].min() >= bbox[0]
+        assert nemo_clipped[grid][f"glam{grid_suffix}"].max() <= bbox[1]
+        assert nemo_clipped[grid][f"gphi{grid_suffix}"].min() >= bbox[2]
+        assert nemo_clipped[grid][f"gphi{grid_suffix}"].max() <= bbox[3]
 
 class TestClipDomain():
     @pytest.mark.parametrize("bbox", [[0, 1, 0, 2], (0, 1), "0 1 2 3"])


### PR DESCRIPTION
## Add new constructors to NEMODataTree

- [x] Add new `.from_icechunk()` constructor to `NEMODataTree` to create `NEMODataTree` from an Icechunk repository, including grid nodes as groups in a version-controlled Zarr store.
- [x] Add new `.from_zarr()` constructor to `NEMODataTree` to create `NEMODataTree` from a hierarchical Zarr store, including grid nodes as groups.
- [x] Add `validate_nemo_grid_node` to validate `NEMODataTree` grid node dims, coords and properties.
- [x] Add `validate_nemo_dataarray` to validate `NEMODataArray` dims, coords and `NEMODataTree`.
- [x] Refactor W-grid creation to use `e1w`, `e2w`, `glamw` and `gphiw` properties (equivalent to T-grid properties) - this removed the need for horizontal grid substitution throughout the codebase. 

### Relevant Modules:
* `nemo_cookbook/nemodatatree.py`
* `nemo_cookbook/nemodataarray.py`
* `tests/test_nemodatatree.py`