### PR TITLE
29 [feature] add from_xesmf method

### DIFF
--- a/docs/docs/howto.md
+++ b/docs/docs/howto.md
@@ -423,4 +423,16 @@ Note, the `to_xesmf()` accessor only supports variables defined on scalar **T**-
 
 For more information on regridding NEMO outputs using [**xESMF**](https://xesmf.readthedocs.io/en/stable/index.html), visit the **Regridding using xESMF** recipe on the [Recipes] page.
 
+### Create a NEMODataArray using an xESMF Dataset
+
+To create a `NEMODataArray` from a variable stored in an [**xESMF**](https://xesmf.readthedocs.io/en/stable/index.html) compatible `xarray.Dataset` following regridding, we can use the `.from_xesmf()` method.
+
+For example, to create a `NEMODataArray` called `tos_obs` from sea surface temperature observations regridded to scalar **T**-points in a NEMO model parent domain using **xESMF**:
+
+```python
+nemo["gridT/tos_obs"] = NEMODataArray.from_xesmf(da=ds_xesmf["tos_obs"], tree=nemo, grid="gridT")
+```
+
+The resulting `NEMODataArray` can now be used for grid-aware computation and for performing model validation.
+
 [Recipes]: recipes.md#summary

--- a/nemo_cookbook/nemodataarray.py
+++ b/nemo_cookbook/nemodataarray.py
@@ -114,6 +114,53 @@ class NEMODataArray:
         t_list = [dim for dim in self._da.coords if "time" in dim]
         self.t_name = t_list[0] if len(t_list) != 0 else None
 
+    # ------------
+    # Constructors
+    # ------------
+    @classmethod
+    def from_xesmf(
+        cls,
+        da: xr.DataArray,
+        tree: NEMODataTree,
+        grid: str
+    ) -> Self:
+        """
+        Convert xESMF-compatible DataArray into a NEMODataArray.
+
+        Parameters
+        ----------
+        da : xr.DataArray
+            xESMF-compatible DataArray to convert to NEMODataArray.
+        tree : NEMODataTree
+            NEMODataTree to associate with the NEMODataArray.
+        grid : str
+            Path to NEMO model grid to which the variable belongs
+            (e.g., 'gridT').
+
+        Returns
+        -------
+        NEMODataArray
+            NEMODataArray containing data from xESMF-compatible DataArray.
+        """
+        # -- Validate Inputs -- #
+        if not isinstance(da, xr.DataArray):
+            raise TypeError("da must be specified as an xarray.DataArray.")
+
+        if not isinstance(tree, xr.DataTree):
+            raise TypeError("tree must be specified as a NEMODataTree.")
+
+        if not isinstance(grid, str):
+            raise TypeError("grid must be specified as a string.")
+
+        # -- Get NEMO model grid properties -- #
+        _, dom_prefix, _, grid_suffix = tree._get_properties(grid=grid, infer_dom=True)
+
+        # -- Transform xESMF coords to NEMO model coords -- #
+        da_nemo = da.rename({"lon": f"{dom_prefix}glam{grid_suffix}",
+                             "lat": f"{dom_prefix}gphi{grid_suffix}"
+                             })
+
+        return cls(da=da_nemo, tree=tree, grid=grid)
 
     # -----------
     # Properties 

--- a/tests/test_nemodataarray.py
+++ b/tests/test_nemodataarray.py
@@ -96,6 +96,48 @@ class TestNEMODataArrayInit:
         nda = nemo["gridT/tos_con"]
         assert isinstance(nda, NEMODataArray)
 
+class TestNEMODataArrayFromXESMF:
+    """
+    Test NEMODataArray.from_xesmf() Input Validation and Functionality.
+    """
+    @pytest.mark.parametrize("da_error", [np.ones((3, 5, 10, 10)), 10, "data", None, [1, 2, 3]])
+    def test_da_type_error(self, da_error, example_global_nemodatatree):
+        nemo = example_global_nemodatatree
+        # Invalid da type (not xarray.DataArray):
+        with pytest.raises(TypeError, match="da must be specified as an xarray.DataArray."):
+            NEMODataArray.from_xesmf(da=da_error, tree=nemo, grid="gridT")
+
+    @pytest.mark.parametrize("tree_error", [42, "tree", None, xr.Dataset()])
+    def test_tree_type_error(self, tree_error, example_global_nemodatatree):
+        nemo = example_global_nemodatatree
+        da = nemo["gridT"]["tos_con"]
+        # Invalid tree type (not NEMODataTree):
+        with pytest.raises(TypeError, match="tree must be specified as a NEMODataTree."):
+            NEMODataArray.from_xesmf(da=da, tree=tree_error, grid="gridT")
+
+    @pytest.mark.parametrize("grid_error", [1, None, ["gridT"], ("gridT",)])
+    def test_grid_type_error(self, grid_error, example_global_nemodatatree):
+        nemo = example_global_nemodatatree
+        da = nemo["gridT"]["tos_con"]
+        # Invalid grid type (not a string):
+        with pytest.raises(TypeError, match="grid must be specified as a string."):
+            NEMODataArray.from_xesmf(da=da, tree=nemo, grid=grid_error)
+
+    @pytest.mark.parametrize("dom_type", ["global", "regional"])
+    def test_from_xesmf_returns_nemodataarray(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
+        nemo = _get_nemodatatree(dom_type, example_global_nemodatatree, example_regional_nemodatatree)
+        # Export NEMO variable to xESMF-compatible DataSet:
+        ds_xesmf = nemo["gridT/tos_con"].to_xesmf(mask=True)
+        nda = NEMODataArray.from_xesmf(da=ds_xesmf['tos_con'], tree=nemo, grid="gridT")
+        assert isinstance(nda, NEMODataArray)
+
+    @pytest.mark.parametrize("dom_type", ["global", "regional"])
+    def test_from_xesmf_preserves_data(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
+        nemo = _get_nemodatatree(dom_type, example_global_nemodatatree, example_regional_nemodatatree)
+        # Export NEMO variable to xESMF-compatible DataSet:
+        ds_xesmf = nemo["gridT/tos_con"].to_xesmf(mask=True)
+        nda = NEMODataArray.from_xesmf(da=ds_xesmf['tos_con'], tree=nemo, grid="gridT")
+        assert np.array_equal(nda.data, ds_xesmf['tos_con'].data, equal_nan=True)
 
 class TestNEMODataArrayProperties:
     """


### PR DESCRIPTION
### [feature] Add `from_xesmf` method to `NEMODataArray`

Add new `from_xesmf()` method to `NEMODataArray` as a class method to create a `NEMODataArray` using a specified variable interpolated onto a given NEMO model grid.

For example, after bilinearly interpolating sea surface temperature observations onto a NEMO model domain T-grid, we would use `from_xesmf()` to add the resulting interpolated, observed SST to our gridT node (parent domain) to allow users to validate against observations.