### PR TITLE
36 refactor improve performance of nemodatatree constructors

### DIFF
--- a/nemo_cookbook/masks.py
+++ b/nemo_cookbook/masks.py
@@ -22,6 +22,7 @@ def read_dom_mask(
     ka: xr.DataArray,
     ds_domain: xr.Dataset,
     cd_nat: str,
+    mask_opensea: xr.DataArray = None,
 ) -> xr.DataArray:
     """
     Read land/ocean mask arrays at tracer points, horizontal velocity
@@ -40,6 +41,9 @@ def read_dom_mask(
     cd_nat : str
         Nature of array grid-points to read land/sea mask for.
         Options are 'T', 'W', 'U', 'V' or 'F'.
+    mask_opensea : xr.DataArray, optional
+        All closed seas are masked using mask_opensea, by default
+        no masking is applied.
 
     Returns
     -------
@@ -66,12 +70,17 @@ def read_dom_mask(
     # Update coordinates to use zero-based indexing:
     mask = mask.assign_coords({"nav_lev": ka, "y": mask["y"], "x": mask["x"]})
 
+    if mask_opensea is not None:
+        # Apply open-sea mask to mask closed seas:
+        mask = mask.where(mask_opensea)
+
     return mask
 
 
 def read_dom_maskutil(
     ds_domain: xr.Dataset,
     cd_nat: str,
+    mask_opensea: xr.DataArray = None,
 ) -> xr.DataArray:
     """
     Read land/ocean mask arrays at tracer points, horizontal velocity
@@ -87,6 +96,9 @@ def read_dom_maskutil(
     cd_nat : str
         Nature of array grid-points to read land/sea mask for.
         Options are 'T', 'W', 'U', 'V' or 'F'.
+    mask_opensea : xr.DataArray, optional
+        All closed seas are masked using mask_opensea, by default
+        no masking is applied.
 
     Returns
     -------
@@ -108,6 +120,10 @@ def read_dom_maskutil(
 
     # Update coordinates to use zero-based indexing:
     mask = mask.assign_coords({"y": mask["y"], "x": mask["x"]})
+
+    if mask_opensea is not None:
+        # Apply open-sea mask to mask closed seas:
+        mask = mask.where(mask_opensea)
 
     return mask
 

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -24,13 +24,10 @@ from nemo_cookbook.extract import (
     get_section_indexes,
     update_boundary_dataset,
 )
-from nemo_cookbook.integrate import compute_depth_integral
-from nemo_cookbook.interpolate import interpolate_grid
 from nemo_cookbook.masks import create_polygon_mask, get_mask_boundary
 from nemo_cookbook.nemodataarray import NEMODataArray
 from nemo_cookbook.processing import create_datatree_dict
 from nemo_cookbook.stats import compute_binned_statistic
-from nemo_cookbook.transform import transform_vertical_coords
 from nemo_cookbook.utils import deprecated
 from nemo_cookbook.validation import validate_nemo_grid_node
 
@@ -73,7 +70,9 @@ class NEMODataTree(xr.DataTree):
         iperio: bool = False,
         nftype: str | None = None,
         read_mask: bool = False,
+        maskcs: bool = False,
         key_linssh: bool = False,
+        vco_ref: bool = False,
         nbghost_child: int = 4,
         **open_kwargs: dict[str, any],
     ) -> Self:
@@ -134,11 +133,18 @@ class NEMODataTree(xr.DataTree):
             pivot. By default, no north fold lateral boundary condition is applied (None).
 
         read_mask: bool = False
-            If True, read NEMO model land/sea mask from domain files. Default is False, meaning masks are computed from top_level and bottom_level domain variables.
+            If True, read NEMO model land/sea mask from domain files. Default is False, meaning masks are computed from top_level and
+            bottom_level domain variables. Default is False.
+
+        maskcs: bool = False
+            If True, all closed seas are masked using mask_opensea variables from domain files. Default is False.
 
         key_linssh: bool = False
             Linear free-surface approximation. If True, vertical coordinates are time-independent and given by (e3t_0, e3u_0, e3v_0, e3w_0) in domain_cfg.
             If False, vertical coordinates are time-dependent and must be specified in NEMO model grid datasets. Default is False.
+
+        vco_ref: bool = False
+            If True, add reference vertical scale factors and compute reference water column heights from domain files. Default is False.
 
         nbghost_child : int = 4
             Number of ghost cells to remove from the western/southern boundaries of the (grand)child domains. Default is 4.
@@ -187,9 +193,13 @@ class NEMODataTree(xr.DataTree):
                 "north fold type (`nftype`) of parent domain must be 'T' (T-pivot fold), 'F' (F-pivot fold), or None."
             )
         if not isinstance(read_mask, bool):
-            raise TypeError("`read_mask` must be a boolean.")
+            raise TypeError("reading land-sea masks from domain_cfg (`read_mask`) must be a boolean.")
+        if not isinstance(maskcs, bool):
+            raise TypeError("masking of closed seas (`maskcs`) must be a boolean.")
         if not isinstance(key_linssh, bool):
             raise TypeError("linear free-surface approximation (`key_linssh`) must be a boolean.")
+        if not isinstance(vco_ref, bool):
+            raise TypeError("reference vertical coordinates (`vco_ref`) must be a boolean.")
         if not isinstance(nbghost_child, int):
             raise TypeError(
                 "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer."
@@ -228,8 +238,10 @@ class NEMODataTree(xr.DataTree):
             iperio=iperio,
             nftype=nftype,
             read_mask=read_mask,
+            maskcs=maskcs,
             nbghost_child=nbghost_child,
             key_linssh=key_linssh,
+            vco_ref=vco_ref,
             open_kwargs=dict(**open_kwargs),
         )
 
@@ -248,6 +260,8 @@ class NEMODataTree(xr.DataTree):
         nftype: str | None = None,
         read_mask: bool = False,
         key_linssh: bool = False,
+        vco_ref: bool = False,
+        maskcs: bool = False,
         nbghost_child: int = 4,
     ) -> Self:
         """
@@ -291,11 +305,18 @@ class NEMODataTree(xr.DataTree):
             pivot. By default, no north fold lateral boundary condition is applied (None).
 
         read_mask: bool = False
-            If True, read NEMO model land/sea mask from domain files. Default is False, meaning masks are computed from top_level and bottom_level domain variables.
+            If True, read NEMO model land/sea mask from domain files. Default is False, meaning masks are computed from top_level and bottom_level
+            domain variables. Default is False.
+
+        maskcs: bool = False
+            If True, all closed seas are masked using mask_opensea variables from domain files. Default is False.
 
         key_linssh: bool = False
             Linear free-surface approximation. If True, vertical coordinates are time-independent and given by (e3t_0, e3u_0, e3v_0, e3w_0) in domain_cfg.
             If False, vertical coordinates are time-dependent and must be specified in NEMO model grid datasets. Default is False.
+
+        vco_ref: bool = False
+            If True, add reference vertical scale factors and compute reference water column heights from domain files. Default is False.
 
         nbghost_child : int = 4
             Number of ghost cells to remove from the western/southern boundaries of the (grand)child domains. Default is 4.
@@ -338,9 +359,13 @@ class NEMODataTree(xr.DataTree):
                 "north fold type (`nftype`) of parent domain must be 'T' (T-pivot fold), 'F' (F-pivot fold), or None."
             )
         if not isinstance(read_mask, bool):
-            raise TypeError("`read_mask` must be a boolean.")
+            raise TypeError("reading land-sea masks from domain_cfg (`read_mask`) must be a boolean.")
+        if not isinstance(maskcs, bool):
+            raise TypeError("masking of closed seas (`maskcs`) must be a boolean.")
         if not isinstance(key_linssh, bool):
             raise TypeError("linear free-surface approximation (`key_linssh`) must be a boolean.")
+        if not isinstance(vco_ref, bool):
+            raise TypeError("reference vertical coordinates (`vco_ref`) must be a boolean.")
         if not isinstance(nbghost_child, int):
             raise TypeError(
                 "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer."
@@ -377,7 +402,9 @@ class NEMODataTree(xr.DataTree):
             iperio=iperio,
             nftype=nftype,
             read_mask=read_mask,
+            maskcs=maskcs,
             key_linssh=key_linssh,
+            vco_ref=vco_ref,
             nbghost_child=nbghost_child,
         )
 

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -443,7 +443,8 @@ class NEMODataTree(xr.DataTree):
             Type of north fold lateral boundary condition to apply. Options are 'T' for T-point pivot or 'F' for F-point
 
         open_kwargs : dict[str, Any], optional
-            Additional keyword arguments to pass to `xarray.open_datatree`. Default is None.
+            Additional keyword arguments to pass to `xarray.open_datatree`.
+            Default is None.
 
         **session_kwargs : dict[str, Any], optional
             Additional keyword arguments to pass to Icechunk `repo.readonly_session`.
@@ -478,7 +479,7 @@ class NEMODataTree(xr.DataTree):
 
         # -- Create NEMODataTree from Icechunk repository -- #:
         session = repo.readonly_session(**session_kwargs)
-        datatree = xr.open_datatree(session.store, engine="zarr", **(open_kwargs or {}))
+        datatree = xr.open_datatree(session.store, engine="zarr", **(open_kwargs or {"chunks": {}}))
         nemo = super().from_dict(datatree.to_dict())
 
         # -- Update NEMODataTree properties -- #
@@ -520,6 +521,7 @@ class NEMODataTree(xr.DataTree):
 
         **open_kwargs : dict[str, Any], optional
             Additional keyword arguments to pass to `xarray.open_datatree`.
+            Default is None.
 
         Returns
         -------
@@ -550,7 +552,7 @@ class NEMODataTree(xr.DataTree):
             )
 
         # -- Create NEMODataTree from Zarr store -- #:
-        datatree = xr.open_datatree(store, engine="zarr", **(open_kwargs or {}))
+        datatree = xr.open_datatree(store, engine="zarr", **(open_kwargs or {"chunks": {}}))
         nemo = super().from_dict(datatree.to_dict())
 
         # -- Update NEMODataTree properties -- #

--- a/nemo_cookbook/processing.py
+++ b/nemo_cookbook/processing.py
@@ -10,6 +10,7 @@ Ollie Tooth (oliver.tooth@noc.ac.uk)
 """
 
 import glob
+import warnings
 
 import numpy as np
 import xarray as xr
@@ -531,7 +532,7 @@ def _add_domain_vars(
         ) from e
 
     # Land-sea masks:
-    if read_mask:
+    if read_mask & ("wmask" in domain.data_vars):
         d_grids["gridW"]["wmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="W", mask_opensea=mask_opensea)
         if "wmaskutil" in domain.data_vars:
             # W-grid is horizontally co-located with T-grid -> use tmaskutil:
@@ -539,6 +540,12 @@ def _add_domain_vars(
         else:
             d_grids["gridW"]["wmaskutil"] = d_grids["gridW"]["wmask"].isel(nav_lev=0).squeeze(drop=True)
     else:
+        if read_mask:
+            warnings.warn(
+                "wmask not found in domain dataset. Creating wmask from top_level and bottom_level variables.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         d_grids["gridW"]["wmask"] = create_dom_mask(
             ka=ka,
             top_level=domain["top_level"],

--- a/nemo_cookbook/processing.py
+++ b/nemo_cookbook/processing.py
@@ -297,9 +297,11 @@ def _open_grid_datasets(
 def _add_domain_vars(
     d_grids: dict[str, xr.Dataset],
     key_linssh: bool = False,
+    vco_ref: bool = False,
     iperio: bool = False,
     nftype: str | None = None,
     read_mask: bool = False,
+    maskcs: bool = False,
 ) -> dict[str, xr.Dataset]:
     """
     Append domain & mask variables to each grid dataset
@@ -322,6 +324,10 @@ def _add_domain_vars(
         (e3t_0, e3u_0, e3v_0, e3w_0). If False, vertical coordinates are time-dependent and must be included
         in grid datasets. Default is False.
 
+    vco_ref: bool = False
+        If True, add reference vertical scale factors and compute reference water column heights from domain files.
+        Default is False.
+
     iperio: bool = False
         Zonal periodicity of the domain.
 
@@ -332,6 +338,9 @@ def _add_domain_vars(
     read_mask : bool = False
         If True, read NEMO model land/sea mask from domain files. Default is False, meaning masks are computed
         from top_level and bottom_level domain variables.
+
+    maskcs : bool = False
+        If True, all closed seas are masked using mask_opensea variables from domain files. Default is False.
 
     Returns
     -------
@@ -348,12 +357,19 @@ def _add_domain_vars(
     if "domain" in d_grids:
         # Remove singleton dimensions from domain dataset:
         domain = d_grids["domain"].squeeze(drop=True)
+        # Drop legacy domain coordinates to prevent broadcasting conflicts:
+        for coord in ("nav_lon", "nav_lat", "nav_lev", "y", "x"):
+            if coord in domain:
+                domain = domain.drop_vars(coord)
     else:
         raise KeyError("missing 'domain' key in grid datasets dictionary.")
 
     # Determine if closed seas should be masked:
-    if "mask_opensea" in domain.data_vars:
-        mask_opensea = domain["mask_opensea"]
+    if maskcs:
+        if "mask_opensea" in domain.data_vars:
+            mask_opensea = domain["mask_opensea"]
+        else:
+            raise KeyError("missing required 'mask_opensea' variable in domain dataset.")
     else:
         mask_opensea = None
 
@@ -376,8 +392,11 @@ def _add_domain_vars(
 
     # Land-sea masks:
     if read_mask:
-        d_grids["gridT"]["tmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="T")
-        d_grids["gridT"]["tmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="T")
+        d_grids["gridT"]["tmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="T", mask_opensea=mask_opensea)
+        if "tmaskutil" in domain.data_vars:
+            d_grids["gridT"]["tmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="T", mask_opensea=mask_opensea)
+        else:
+            d_grids["gridT"]["tmaskutil"] = d_grids["gridT"]["tmask"].isel(nav_lev=0).squeeze(drop=True)
     else:
         d_grids["gridT"]["tmask"] = create_dom_mask(
             ka=ka,
@@ -388,12 +407,12 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-        d_grids["gridT"]["tmaskutil"] = d_grids["gridT"]["tmask"][0, :, :].squeeze(
+        d_grids["gridT"]["tmaskutil"] = d_grids["gridT"]["tmask"].isel(nav_lev=0).squeeze(
             drop=True
         )
 
     # Reference vertical scale factors and water column heights:
-    if "e3t_0" in domain.data_vars:
+    if vco_ref and ("e3t_0" in domain.data_vars):
         if not key_linssh:
             # Add reference vertical scale factors:
             d_grids["gridT"]["e3t_0"] = domain["e3t_0"]
@@ -421,8 +440,11 @@ def _add_domain_vars(
 
     # Land-sea masks:
     if read_mask:
-        d_grids["gridU"]["umask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="U")
-        d_grids["gridU"]["umaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="U")
+        d_grids["gridU"]["umask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="U", mask_opensea=mask_opensea)
+        if "umaskutil" in domain.data_vars:
+            d_grids["gridU"]["umaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="U", mask_opensea=mask_opensea)
+        else:
+            d_grids["gridU"]["umaskutil"] = d_grids["gridU"]["umask"].isel(nav_lev=0).squeeze(drop=True)
     else:
         d_grids["gridU"]["umask"] = create_dom_mask(
             ka=ka,
@@ -433,12 +455,10 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-        d_grids["gridU"]["umaskutil"] = d_grids["gridU"]["umask"][0, :, :].squeeze(
-            drop=True
-        )
+        d_grids["gridU"]["umaskutil"] = d_grids["gridU"]["umask"].isel(nav_lev=0).squeeze(drop=True)
 
     # Reference vertical scale factors and water column heights:
-    if "e3u_0" in domain.data_vars:
+    if vco_ref and ("e3u_0" in domain.data_vars):
         if not key_linssh:
             # Add reference vertical scale factors:
             d_grids["gridU"]["e3u_0"] = domain["e3u_0"]
@@ -466,8 +486,11 @@ def _add_domain_vars(
 
     # Land-sea masks:
     if read_mask:
-        d_grids["gridV"]["vmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="V")
-        d_grids["gridV"]["vmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="V")
+        d_grids["gridV"]["vmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="V", mask_opensea=mask_opensea)
+        if "vmaskutil" in domain.data_vars:
+            d_grids["gridV"]["vmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="V", mask_opensea=mask_opensea)
+        else:
+            d_grids["gridV"]["vmaskutil"] = d_grids["gridV"]["vmask"].isel(nav_lev=0).squeeze(drop=True)
     else:
         d_grids["gridV"]["vmask"] = create_dom_mask(
             ka=ka,
@@ -478,12 +501,10 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-        d_grids["gridV"]["vmaskutil"] = d_grids["gridV"]["vmask"][0, :, :].squeeze(
-            drop=True
-        )
+        d_grids["gridV"]["vmaskutil"] = d_grids["gridV"]["vmask"].isel(nav_lev=0).squeeze(drop=True)
 
     # Reference vertical scale factors and water column heights:
-    if "e3v_0" in domain.data_vars:
+    if vco_ref and ("e3v_0" in domain.data_vars):
         if not key_linssh:
             # Add reference vertical scale factors:
             d_grids["gridV"]["e3v_0"] = domain["e3v_0"]
@@ -511,9 +532,12 @@ def _add_domain_vars(
 
     # Land-sea masks:
     if read_mask:
-        d_grids["gridW"]["wmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="W")
-        # W-grid is horizontally co-located with T-grid -> use tmaskutil:
-        d_grids["gridW"]["wmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="T")
+        d_grids["gridW"]["wmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="W", mask_opensea=mask_opensea)
+        if "wmaskutil" in domain.data_vars:
+            # W-grid is horizontally co-located with T-grid -> use tmaskutil:
+            d_grids["gridW"]["wmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="T", mask_opensea=mask_opensea)
+        else:
+            d_grids["gridW"]["wmaskutil"] = d_grids["gridW"]["wmask"].isel(nav_lev=0).squeeze(drop=True)
     else:
         d_grids["gridW"]["wmask"] = create_dom_mask(
             ka=ka,
@@ -524,12 +548,10 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-        d_grids["gridW"]["wmaskutil"] = d_grids["gridW"]["wmask"][0, :, :].squeeze(
-            drop=True
-        )
+        d_grids["gridW"]["wmaskutil"] = d_grids["gridW"]["wmask"].isel(nav_lev=0).squeeze(drop=True)
 
     # Reference vertical scale factors and water column heights:
-    if "e3w_0" in domain.data_vars:
+    if vco_ref and ("e3w_0" in domain.data_vars):
         if not key_linssh:
             # Add reference vertical scale factors:
             d_grids["gridW"]["e3w_0"] = domain["e3w_0"]
@@ -553,8 +575,11 @@ def _add_domain_vars(
 
     # Land-sea masks:
     if read_mask:
-        d_grids["gridF"]["fmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="F")
-        d_grids["gridF"]["fmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="F")
+        d_grids["gridF"]["fmask"] = read_dom_mask(ka=ka, ds_domain=domain, cd_nat="F", mask_opensea=mask_opensea)
+        if "fmaskutil" in domain.data_vars:
+            d_grids["gridF"]["fmaskutil"] = read_dom_maskutil(ds_domain=domain, cd_nat="F", mask_opensea=mask_opensea)
+        else:
+            d_grids["gridF"]["fmaskutil"] = d_grids["gridF"]["fmask"].isel(nav_lev=0).squeeze(drop=True)
     else:
         d_grids["gridF"]["fmask"] = create_dom_mask(
             ka=ka,
@@ -565,12 +590,10 @@ def _add_domain_vars(
             iperio=iperio,
             mask_opensea=mask_opensea,
         )
-        d_grids["gridF"]["fmaskutil"] = d_grids["gridF"]["fmask"][0, :, :].squeeze(
-            drop=True
-        )
+        d_grids["gridF"]["fmaskutil"] = d_grids["gridF"]["fmask"].isel(nav_lev=0).squeeze(drop=True)
 
     # Reference vertical scale factors and water column heights:
-    if "e3f_0" in domain.data_vars:
+    if vco_ref and ("e3f_0" in domain.data_vars):
         if not key_linssh:
             # Add reference vertical scale factors:
             d_grids["gridF"]["e3f_0"] = domain["e3f_0"]
@@ -701,7 +724,9 @@ def _process_parent(
     iperio: bool = False,
     nftype: str | None = None,
     read_mask: bool = False,
+    maskcs: bool = False,
     key_linssh: bool = False,
+    vco_ref: bool = False,
     open_kwargs: dict[str, any] | None = None,
 ) -> dict[str, xr.Dataset]:
     """
@@ -739,16 +764,23 @@ def _process_parent(
 
     read_mask : bool = False
         If True, read NEMO model land/sea mask from domain files. Default is False, meaning masks are computed
-        from top_level and bottom_level domain variables.
+        from top_level and bottom_level domain variables. Default is False.
+
+    maskcs : bool = False
+        If True, all closed seas are masked using mask_opensea variables from domain files. Default is False.
 
     key_linssh: bool = False
         Linear free-surface approximation. If True, vertical coordinates are time-independent and given by
         (e3t_0, e3u_0, e3v_0, e3w_0). If False, vertical coordinates are time-dependent and must be included
         in grid datasets. Default is False.
 
+    vco_ref: bool = False
+        If True, add reference vertical scale factors and compute reference water column heights from domain files.
+        Default is False.
+
     open_kwargs: dict[str, any], optional
         Additional keyword arguments to pass to xarray.open_dataset or xarray.open_mfdataset when opening
-        parent grid files.
+        parent grid files. Default is None.
 
     Returns
     -------
@@ -783,7 +815,8 @@ def _process_parent(
 
     # Add domain variables to each grid dataset:
     d_grids = _add_domain_vars(
-        d_grids=d_grids, key_linssh=key_linssh, iperio=iperio, nftype=nftype, read_mask=read_mask
+        d_grids=d_grids, key_linssh=key_linssh, iperio=iperio, nftype=nftype,
+        read_mask=read_mask, maskcs=maskcs, vco_ref=vco_ref
     )
 
     # Process T / U / V / W / F grids:
@@ -826,8 +859,10 @@ def _process_child(
     label: int,
     parent_label: int,
     read_mask: bool = False,
+    maskcs: bool = False,
     nbghost_child: int = _DEFAULT_NBGHOST_CHILD,
     key_linssh: bool = False,
+    vco_ref: bool = False,
     open_kwargs: dict[str, any] | None = None,
 ) -> dict[str, xr.Dataset]:
     """
@@ -877,7 +912,10 @@ def _process_child(
 
     read_mask : bool = False
         If True, read NEMO model land/sea mask from domain files. Default is False, meaning masks are computed
-        from top_level and bottom_level domain variables.
+        from top_level and bottom_level domain variables. Default is False.
+
+    maskcs : bool = False
+        If True, all closed seas are masked using mask_opensea variables from domain files. Default is False.
 
     nbghost_child : int = _DEFAULT_NBGHOST_CHILD
         Number of ghost cells to remove from the western/southern boundaries of the (grand)child domain.
@@ -888,9 +926,13 @@ def _process_child(
         (e3t_0, e3u_0, e3v_0, e3w_0). If False, vertical coordinates are time-dependent and must be included
         in grid datasets. Default is False.
 
+    vco_ref: bool = False
+        If True, add reference vertical scale factors and compute reference water column heights from domain files.
+        Default is False.
+
     open_kwargs: dict[str, any], optional
         Additional keyword arguments to pass to xarray.open_dataset or xarray.open_mfdataset when opening
-        (grand)child grid files.
+        (grand)child grid files. Default is None.
 
     Returns
     -------
@@ -933,7 +975,8 @@ def _process_child(
 
     # Add child domain variables to each grid:
     d_grids = _add_domain_vars(
-        d_grids=d_grids, key_linssh=key_linssh, iperio=d_nests["iperio"], nftype=None, read_mask=read_mask
+        d_grids=d_grids, key_linssh=key_linssh, iperio=d_nests["iperio"], nftype=None,
+        read_mask=read_mask, maskcs=maskcs, vco_ref=vco_ref
     )
 
     # Get child domain indices excluding ghost cells:
@@ -1010,8 +1053,10 @@ def create_datatree_dict(
     iperio: bool = False,
     nftype: str | None = None,
     read_mask: bool = False,
+    maskcs: bool = False,
     nbghost_child: int = _DEFAULT_NBGHOST_CHILD,
     key_linssh: bool = False,
+    vco_ref: bool = False,
     open_kwargs: dict[str, any] | None = None,
 ) -> dict[str, xr.Dataset]:
     """
@@ -1034,15 +1079,20 @@ def create_datatree_dict(
         Type of north fold lateral boundary condition to apply to parent domain. Options are 'T' for T-point
         pivot or 'F' for F-point pivot. By default, no north fold lateral boundary condition is applied (None).
     read_mask : bool = False
-        If True, read NEMO model land/sea mask from domain files. Default is False, meaning masks are computed from top_level and bottom_level domain variables.
+        If True, read NEMO model land/sea mask from domain files. Default is False, meaning masks are computed from top_level and bottom_level
+        domain variables. Default is False.
+    maskcs: bool = False
+        If True, all closed seas are masked using mask_opensea variables from domain files. Default is False.
     nbghost_child : int = _DEFAULT_NBGHOST_CHILD
         Number of ghost cells to remove from the western/southern boundaries of the (grand)child domain. Default is 4 (`_DEFAULT_NBGHOST_CHILD`).
     key_linssh: bool = False
         Linear free-surface approximation. If True, vertical coordinates are time-independent and given by (e3t_0, e3u_0, e3v_0, e3w_0). If False, vertical
         coordinates are time-dependent and must be included in grid datasets. Default is False.
+    vco_ref: bool = False
+        If True, add reference vertical scale factors and compute reference water column heights from domain files. Default is False.
     open_kwargs : dict[str, any], optional
         Additional keyword arguments passed to `xarray.open_dataset` or `xarray.open_mfdataset` when
-        opening NEMO grid files.
+        opening NEMO grid files. Default is None.
 
     Returns
     -------
@@ -1058,8 +1108,10 @@ def create_datatree_dict(
         d_parent=d_parent,
         iperio=iperio,
         read_mask=read_mask,
+        maskcs=maskcs,
         nftype=nftype,
         key_linssh=key_linssh,
+        vco_ref=vco_ref,
         open_kwargs=open_kwargs,
     )
 
@@ -1084,8 +1136,10 @@ def create_datatree_dict(
                     label=int(key),
                     parent_label=None,
                     read_mask=read_mask,
+                    maskcs=maskcs,
                     nbghost_child=nbghost_child,
                     key_linssh=key_linssh,
+                    vco_ref=vco_ref,
                     open_kwargs=open_kwargs,
                 )
             )
@@ -1115,8 +1169,10 @@ def create_datatree_dict(
                     label=int(key),
                     parent_label=int(d_nests["parent"]),
                     read_mask=read_mask,
+                    maskcs=maskcs,
                     nbghost_child=nbghost_child,
                     key_linssh=key_linssh,
+                    vco_ref=vco_ref,
                     open_kwargs=open_kwargs,
                 )
             )

--- a/nemo_cookbook/processing.py
+++ b/nemo_cookbook/processing.py
@@ -19,10 +19,15 @@ from .masks import create_dom_mask, read_dom_mask, read_dom_maskutil
 
 _DEFAULT_NBGHOST_CHILD = 4
 
-def _add_parent_indices(ds: xr.Dataset, grid: str, label: str) -> xr.Dataset:
+def _add_parent_indices(
+    ds: xr.Dataset,
+    grid: str,
+    parent: str,
+    label: str
+    ) -> xr.Dataset:
     """
     Add coordinates mapping parent domain (i, j) indices
-    to child domain (i_c, j_c) indices.
+    to child domain (ip_c, jp_c) indices.
 
     Parameters
     ----------
@@ -30,6 +35,8 @@ def _add_parent_indices(ds: xr.Dataset, grid: str, label: str) -> xr.Dataset:
         NEMO model grid dataset.
     grid : str
         Name of the NEMO model grid (e.g. 'gridT', 'gridU', etc.).
+    parent : str
+        Identity of the NEMO model parent domain (e.g. '/', '1', '2', etc.).
     label : str
         Label to append to grid variable names.
 
@@ -37,10 +44,13 @@ def _add_parent_indices(ds: xr.Dataset, grid: str, label: str) -> xr.Dataset:
     -------
     xr.Dataset
         NEMO model grid dataset including coordinates mapping
-        parent domain (i, j) indices to child domain (i_c, j_c)
+        parent domain (i, j) indices to child domain (ip_c, jp_c)
         indices.
     """
-    # Define parent domain (i, j) indices for each child domain (i_c, j_c) index:
+    # Define parent domain label:
+    plabel = "" if parent == "/" else parent
+
+    # Define parent domain (i, j) indices for each child domain (ip_c, jp_c) index:
     if grid in ["gridU", "gridF"]:
         i_child = np.arange(ds.attrs["imin"] + 0.5, ds.attrs["imax"] + 0.5)
     else:
@@ -50,10 +60,10 @@ def _add_parent_indices(ds: xr.Dataset, grid: str, label: str) -> xr.Dataset:
         dims=[f"i{label}"],
         coords={f"i{label}": ds[f"i{label}"]},
     )
-    ds[f"i_i{label}"] = i_ic
-    ds[f"i_i{label}"] = ds[f"i_i{label}"].assign_attrs(
-        name=f"i_i{label}",
-        long_name=f"parent domain i indices of child domain i{label} indices",
+    ds[f"i{plabel}_i{label}"] = i_ic
+    ds[f"i{plabel}_i{label}"] = ds[f"i{plabel}_i{label}"].assign_attrs(
+        name=f"i{plabel}_i{label}",
+        long_name=f"i{plabel} indices of child domain i{label} indices",
     )
 
     if grid in ["gridV", "gridF"]:
@@ -65,14 +75,16 @@ def _add_parent_indices(ds: xr.Dataset, grid: str, label: str) -> xr.Dataset:
         dims=[f"j{label}"],
         coords={f"j{label}": ds[f"j{label}"]},
     )
-    ds[f"j_j{label}"] = j_jc
-    ds[f"j_j{label}"] = ds[f"j_j{label}"].assign_attrs(
-        name=f"j_j{label}",
-        long_name=f"parent domain j indices of child domain j{label} indices",
+    ds[f"j{plabel}_j{label}"] = j_jc
+    ds[f"j{plabel}_j{label}"] = ds[f"j{plabel}_j{label}"].assign_attrs(
+        name=f"j{plabel}_j{label}",
+        long_name=f"j{plabel} indices of child domain j{label} indices",
     )
 
     ds = ds.assign_coords(
-        {f"i_i{label}": ds[f"i_i{label}"], f"j_j{label}": ds[f"j_j{label}"]}
+        {f"i{plabel}_i{label}": ds[f"i{plabel}_i{label}"],
+         f"j{plabel}_j{label}": ds[f"j{plabel}_j{label}"]
+        }
     )
 
     return ds
@@ -1026,6 +1038,7 @@ def _process_child(
                 }
             ),
             grid=grid,
+            parent=d_nests.get("parent"),
             label=label,
         )
 

--- a/recipes/recipe_cmip6.ipynb
+++ b/recipes/recipe_cmip6.ipynb
@@ -32,7 +32,7 @@
     {
      "data": {
       "text/plain": [
-       "<xarray.core.options.set_options at 0x303e5f770>"
+       "<xarray.core.options.set_options at 0x3137b7770>"
       ]
      },
      "execution_count": 1,
@@ -154,7 +154,7 @@
     "domain_url = \"https://noc-msm-o.s3-ext.jc.rl.ac.uk/nemo-cookbook/ukesm1/domain_cfg\"\n",
     "\n",
     "# Open eORCA1 NEMO model domain_cfg:\n",
-    "ds_domain = xr.open_zarr(domain_url, consolidated=True, chunks={}) #.drop_vars([\"nav_lev\"])\n",
+    "ds_domain = xr.open_zarr(domain_url, consolidated=True, chunks={})\n",
     "\n",
     "ds_domain"
    ]
@@ -379,12 +379,14 @@
    "source": [
     "### **Creating a NEMODataTree**\n",
     "\n",
-    "**Next, let's create a NEMODataTree to store our domain and T & V-grid variables for the UKESM1-0-LL ocean component between 2004-2015.**"
+    "**Next, let's create a NEMODataTree to store our domain and T & V-grid variables for the UKESM1-0-LL ocean component between 2004-2015.**\n",
+    "\n",
+    "**Here, we use `vco_ref=True` to add the reference vertical scale factors `e3{t/u/v/f/w}_0` and water column heights `h{t/u/v/f/w}_0` to our NEMODataTree:**"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -690,8 +692,9 @@
     "             }\n",
     "            }\n",
     "\n",
-    "# Initialise a new NEMODataTree whose parent domain is zonally periodic & north-folding on F-points:\n",
-    "nemo = NEMODataTree.from_datasets(datasets=datasets, iperio=True, nftype=\"F\", read_mask=True, name=\"UKESM1-0-LL\")\n",
+    "# Initialise a new NEMODataTree whose parent domain is zonally periodic, north-folding on F-points including reference\n",
+    "# vertical scale factors and water column heights:\n",
+    "nemo = NEMODataTree.from_datasets(datasets=datasets, iperio=True, nftype=\"F\", read_mask=True, vco_ref=True, name=\"UKESM1-0-LL\")\n",
     "\n",
     "nemo"
    ]
@@ -721,7 +724,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x3161963c0>"
+       "<matplotlib.collections.QuadMesh at 0x33df96510>"
       ]
      },
      "execution_count": 6,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -568,6 +568,34 @@ def example_ORCA2_linssh_nemodatatree() -> NEMODataTree:
     return nemo
 
 @pytest.fixture
+def example_ORCA2_vco_ref_nemodatatree() -> NEMODataTree:
+    """
+    Fixture to create an example ORCA2 global NEMODataTree including vertical grid scale factor and water column
+    references using AGRIF_DEMO configuration. The global model domain is zonally periodic (i.e., iperio = True).
+
+    Returns
+    -------
+    NEMODataTree
+        Example ORCA2 global NEMODataTree including vertical grid scale factor and water column references.
+    """
+    # -- Create example vco_ref NEMODataTree from AGRIF_DEMO configuration -- #
+    # Get dict of example filepaths:
+    filepaths = get_filepaths("AGRIF_DEMO")
+    # Define paths dict for NEMODataTree:
+    paths = {"parent": {
+                "domain": filepaths["domain_cfg.nc"],
+                "gridT": filepaths["ORCA2_5d_00010101_00010110_grid_T.nc"],
+                "gridU": filepaths["ORCA2_5d_00010101_00010110_grid_U.nc"],
+                "gridV": filepaths["ORCA2_5d_00010101_00010110_grid_V.nc"],
+                "gridW": filepaths["ORCA2_5d_00010101_00010110_grid_W.nc"],
+                "icemod": filepaths["ORCA2_5d_00010101_00010110_icemod.nc"]
+            }}
+    # Create NEMODataTree from paths dict:
+    nemo = NEMODataTree.from_paths(paths, name="Example ORCA2", iperio=True, nftype="T", vco_ref=True)
+
+    return nemo
+
+@pytest.fixture
 def example_AMM12_nemodatatree() -> NEMODataTree:
     """
     Fixture to create an example AMM12 regional NEMODataTree using AMM12 configuration.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -77,6 +77,23 @@ class TestNEMODataTreeExamples():
         # Close files associated with NEMODataTree:
         nemo.close()
 
+    def test_orca2_vco_ref_nemodatatree(self, example_ORCA2_vco_ref_nemodatatree):
+        # -- Create example vco_ref NEMODataTree from AGRIF_DEMO configuration -- #
+        nemo = example_ORCA2_vco_ref_nemodatatree
+
+        # -- Verify grid nodes, scale factors & coordinates -- #
+        assert isinstance(nemo, xr.DataTree)
+        nodes = [entry[0] for entry in list(nemo.subtree_with_keys)]
+        for node in ['gridT', 'gridU', 'gridV', 'gridF']:
+            assert node in nodes
+            grid_suffix = node[-1].lower()
+            assert f"e3{grid_suffix}_0" in nemo[node].data_vars
+            assert f"h{grid_suffix}_0" in nemo[node].data_vars
+
+        # -- Tear down -- #
+        # Close files associated with NEMODataTree:
+        nemo.close()
+
 
     def test_amm12_nemodatatree(self, example_AMM12_nemodatatree):
         # -- Create example NEMODataTree for AMM12 configuration -- #

--- a/tests/test_nemodatatree.py
+++ b/tests/test_nemodatatree.py
@@ -57,8 +57,14 @@ class TestNEMODataTreePaths():
     @pytest.mark.parametrize("read_mask", ["False", 0])
     def test_read_mask_errors(self, read_mask):
         # -- Verify TypeError -- #
-        with pytest.raises(TypeError, match=re.escape("`read_mask` must be a boolean.")):
+        with pytest.raises(TypeError, match=re.escape("reading land-sea masks from domain_cfg (`read_mask`) must be a boolean.")):
             NEMODataTree.from_paths(paths={}, read_mask=read_mask)
+
+    @pytest.mark.parametrize("maskcs", ["False", 0])
+    def test_maskcs_errors(self, maskcs):
+        # -- Verify TypeError -- #
+        with pytest.raises(TypeError, match=re.escape("masking of closed seas (`maskcs`) must be a boolean.")):
+            NEMODataTree.from_paths(paths={}, maskcs=maskcs)
 
     @pytest.mark.parametrize("key_linssh", ["False", 0])
     def test_key_linssh_errors(self, key_linssh):
@@ -66,6 +72,12 @@ class TestNEMODataTreePaths():
         expected_str = "linear free-surface approximation (`key_linssh`) must be a boolean."
         with pytest.raises(TypeError, match=re.escape(expected_str)):
             NEMODataTree.from_paths(paths={}, key_linssh=key_linssh)
+
+    @pytest.mark.parametrize("vco_ref", ["False", 0])
+    def test_vco_ref_errors(self, vco_ref):
+        # -- Verify TypeError -- #
+        with pytest.raises(TypeError, match=re.escape("reference vertical coordinates (`vco_ref`) must be a boolean.")):
+            NEMODataTree.from_paths(paths={}, vco_ref=vco_ref)
 
     @pytest.mark.parametrize("nbghost_child", ["1", 1.5, None])
     def test_nbghost_child_errors(self, nbghost_child):
@@ -145,8 +157,14 @@ class TestNEMODataTreeDatasets():
     @pytest.mark.parametrize("read_mask", ["False", 0])
     def test_read_mask_errors(self, read_mask):
         # -- Verify TypeError -- #
-        with pytest.raises(TypeError, match=re.escape("`read_mask` must be a boolean.")):
+        with pytest.raises(TypeError, match=re.escape("reading land-sea masks from domain_cfg (`read_mask`) must be a boolean.")):
             NEMODataTree.from_datasets(datasets={}, read_mask=read_mask)
+
+    @pytest.mark.parametrize("maskcs", ["False", 0])
+    def test_maskcs_errors(self, maskcs):
+        # -- Verify TypeError -- #
+        with pytest.raises(TypeError, match=re.escape("masking of closed seas (`maskcs`) must be a boolean.")):
+            NEMODataTree.from_datasets(datasets={}, maskcs=maskcs)
 
     @pytest.mark.parametrize("key_linssh", ["False", 0])
     def test_key_linssh_errors(self, key_linssh):
@@ -154,6 +172,13 @@ class TestNEMODataTreeDatasets():
         expected_str = "linear free-surface approximation (`key_linssh`) must be a boolean."
         with pytest.raises(TypeError, match=re.escape(expected_str)):
             NEMODataTree.from_datasets(datasets={}, key_linssh=key_linssh)
+
+    @pytest.mark.parametrize("vco_ref", ["False", 0])
+    def test_vco_ref_errors(self, vco_ref):
+        # -- Verify TypeError -- #
+        expected_str = "reference vertical coordinates (`vco_ref`) must be a boolean."
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            NEMODataTree.from_paths(paths={}, vco_ref=vco_ref)
 
     @pytest.mark.parametrize("nbghost_child", ["1", 1.5, None])
     def test_nbghost_child_errors(self, nbghost_child):
@@ -193,6 +218,14 @@ class TestNEMODataTreeDatasets():
         # -- Verify output type -- #
         result = NEMODataTree.from_datasets(datasets=datasets)
         assert isinstance(result, NEMODataTree) & isinstance(result, xr.DataTree)
+
+    def test_missing_maskcs(self):
+        # -- Create example paths dict -- #
+        paths = {'parent': {'domain': xr.Dataset()}}
+        # -- Verify KeyError -- #
+        expected_str = "missing required 'mask_opensea' variable in domain dataset."
+        with pytest.raises(KeyError, match=re.escape(expected_str)):
+            NEMODataTree.from_paths(paths=paths, maskcs=True)
 
 class TestNEMODataTreeFromIcechunk():
     def test_repo_errors(self):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -56,10 +56,10 @@ def create_child_dataset():
 
 
 @pytest.mark.parametrize("grid", ['gridT', 'gridU', 'gridV', 'gridW', 'gridF'])
-def test_add_parent_indices(create_child_dataset, grid):
+def test_add_child_parent_indices(create_child_dataset, grid):
     # -- Create example child dataset -- #
     ds = create_child_dataset(grid=grid)
-    ds_out = processing._add_parent_indices(ds=ds, grid=grid, label='2')
+    ds_out = processing._add_parent_indices(ds=ds, grid=grid, parent="/", label='2')
     # -- Verify type -- #
     assert isinstance(ds_out, xr.Dataset)
     # -- Verify coords -- #
@@ -78,6 +78,30 @@ def test_add_parent_indices(create_child_dataset, grid):
     elif 'gridF' in grid:
         assert all(ds_out['i_i2'] % 1 == 0.5)
         assert all(ds_out['j_j2'] % 1 == 0.5)
+
+@pytest.mark.parametrize("grid", ['gridT', 'gridU', 'gridV', 'gridW', 'gridF'])
+def test_add_grandchild_parent_indices(create_child_dataset, grid):
+    # -- Create example grandchild dataset -- #
+    ds = create_child_dataset(grid=grid)
+    ds_out = processing._add_parent_indices(ds=ds, grid=grid, parent="1", label='2')
+    # -- Verify type -- #
+    assert isinstance(ds_out, xr.Dataset)
+    # -- Verify coords -- #
+    assert 'i1_i2' in ds_out.coords
+    assert 'j1_j2' in ds_out.coords
+    # -- Verify coord values -- #
+    if ('gridT' in grid) or ('gridW' in grid):
+        assert all(ds_out['i1_i2'] % 1 == 0)
+        assert all(ds_out['j1_j2'] % 1 == 0)
+    elif 'gridU' in grid:
+        assert all(ds_out['i1_i2'] % 1 == 0.5)
+        assert all(ds_out['j1_j2'] % 1 == 0)
+    elif 'gridV' in grid:
+        assert all(ds_out['i1_i2'] % 1 == 0)
+        assert all(ds_out['j1_j2'] % 1 == 0.5)
+    elif 'gridF' in grid:
+        assert all(ds_out['i1_i2'] % 1 == 0.5)
+        assert all(ds_out['j1_j2'] % 1 == 0.5)
 
 
 def test_get_child_indices():


### PR DESCRIPTION
### Improve performance and robustness of NEMODataTree `from_paths()` and `from_dataset()` constructors.

- [x] Add `vco_ref` parameter to enable calculation of reference vertical grid scale factors and water column heights during NEMODataTree construction.
- [x] Add `maskcs` parameter to enable masking of closed seas using the `mask_opensea` variable in `domain_cfg`.
- [x] Improve fallback option to define 2-dimensional land-sea masks  from available 3-dimensional land-sea masks when using `read_mask=True` where a given `maskutill` variable is missing.
- [x] Remove existing coordinate variables from input `domain_cfg` to avoid broadcasting conflicts.

Closes #36 