### PR TITLE
47 add option to retain ghost points in nested nemodatatrees

### DIFF
--- a/docs/docs/howto.md
+++ b/docs/docs/howto.md
@@ -26,7 +26,9 @@ NEMODataTree.from_paths(paths, iperio=True, nftype="T")
 
 In the example above, we consider only a global parent domain, which is zonally periodic (`iperio=True`) and north-folding on **T** grid points (`nftype="T"`). Note, that we are only required to specify paths for one or more NEMO model grid types (e.g., `*_gridT.nc`).
 
-For NEMO models using a linear free surface approximation (i.e., vertical scale factors are time-independent), we should also specify `key_linssh=True` to read these directly from the domain_cfg file included in the `paths` dictionary.
+For NEMO models using a linear free surface approximation (i.e., vertical scale factors are time-independent), we should also specify `linssh=True` to read these directly from the domain_cfg file included in the `paths` dictionary.
+
+Additionally, for NEMO models configured with more complex vertical coordinates (e.g., MEs or sigma-coordinates), such that vertical reference variables (e.g., `depth`) vary spatially, we should also specify `vco="3d"` to include all vertical reference variables as 3-dimensional arrays analogously to using `key_vco_3d` within NEMO itself. By default, a `NEMODataTree` is constructed using 1-dimensional vertical reference variables.
 
 ### Create a NEMODataTree from `xarray.Datasets`
 

--- a/docs/docs/user_guide.md
+++ b/docs/docs/user_guide.md
@@ -178,9 +178,9 @@ This is because domain variables are assigned to their respective grid nodes dur
 
     Typically, NEMO model simulations use a quasi-eulerian vertical coordinate which absorbs the divergence of horizontal barotropic velocities (e.g., $z^{*}$ or $s^{*}$), meaning that vertical grid scale factors evolve through time (i.e., a time-varying free surface translates into variations in grid cell thickness).
 
-    `NEMODataTree` considers the case of time-evolving vertical grid scale factors to be the default as the `key_linssh` argument to the `.from_paths()` and `.from_datasets()` constructors is set to be `False` by default. This means that vertical grid scale factors must be provided in the netCDF files or `xarray.Datasets` used to define each NEMO model grid node in the `NEMODataTree`.
+    `NEMODataTree` considers the case of time-evolving vertical grid scale factors to be the default as the `linssh` argument to the `.from_paths()` and `.from_datasets()` constructors is set to be `False` by default. This means that vertical grid scale factors must be provided in the netCDF files or `xarray.Datasets` used to define each NEMO model grid node in the `NEMODataTree`.
 
-    For NEMO model simulations using a linear free surface approximation (i.e., variations in the free surface are neglected compared to the depth of the ocean), we should use `key_linssh=True` to indicate that vertical grid scale factors remain fixed through time and should be read directly from the reference variables contained within the domain_cfg netCDF file or `xarray.Dataset` (e.g., `e3t_0`, `e3u_0` etc.).
+    For NEMO model simulations using a linear free surface approximation (i.e., variations in the free surface are neglected compared to the depth of the ocean), we should use `linssh=True` to indicate that vertical grid scale factors remain fixed through time and should be read directly from the reference variables contained within the domain_cfg netCDF file or `xarray.Dataset` (e.g., `e3t_0`, `e3u_0` etc.).
 
 **Dimensions & Coordinates**
 
@@ -268,11 +268,11 @@ In summary, defining a `NEMODataTree` for a nested configuration includes two im
 
     4. Redefine the `dims` and `coords` of each grid dataset to use `i{dom}`, `j{dom}`, `k{dom}` as used to define the semi-discrete equations in NEMO, where *dom* is the unique domain number.
 
-    5. **Clip nested child domains to remove ghost points along the boundaries & add a mapping from the parent grid indices to the child grid indices to the `coords`.**
+    5. **Clip nested child domains to remove ghost points along the boundaries & add a mapping from the parent grid indices to the child grid indices to the `coords`.** Alternatively, the entire child domain, including ghost points, can be retained by passing `nbghost_child=None` to the `.from_paths()` and `.from_datasets()` constructors.
 
     6. **Assemble dictionaries of processed NEMO model grid datasets for each of the parent, child and grandchild domains.**
 
-    7. Assemble the `xarray.DataTree` using a nested dictionary of NEMO model domains.
+    7. Assemble the underlying `xarray.DataTree` using a nested dictionary of NEMO model domains.
 
 ### NEMODataArray :ocean: :simple-databricks:
 ---

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -74,7 +74,7 @@ class NEMODataTree(xr.DataTree):
         linssh: bool = False,
         vco: str = "1d",
         vco_ref: bool = False,
-        nbghost_child: int = 4,
+        nbghost_child: int | None = 4,
         **open_kwargs: dict[str, any],
     ) -> Self:
         """
@@ -150,8 +150,9 @@ class NEMODataTree(xr.DataTree):
         vco_ref: bool = False
             If True, add reference vertical scale factors and compute reference water column heights from domain files. Default is False.
 
-        nbghost_child : int = 4
+        nbghost_child : int | None = 4
             Number of ghost cells to remove from the western/southern boundaries of the (grand)child domains. Default is 4.
+            If None, no ghost cells are removed and the full (grand)child domain is used.
 
         **open_kwargs : dict, optional
             Additional keyword arguments to pass to `xarray.open_dataset` or `xr.open_mfdataset` when opening NEMO model output files.
@@ -210,9 +211,9 @@ class NEMODataTree(xr.DataTree):
             )
         if not isinstance(vco_ref, bool):
             raise TypeError("reference vertical coordinates (`vco_ref`) must be a boolean.")
-        if not isinstance(nbghost_child, int):
+        if not isinstance(nbghost_child, (int, type(None))):
             raise TypeError(
-                "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer."
+                "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer or None."
             )
         if not isinstance(open_kwargs, dict):
             raise TypeError("`open_kwargs` must be a dictionary.")
@@ -274,7 +275,7 @@ class NEMODataTree(xr.DataTree):
         vco: str = "1d",
         vco_ref: bool = False,
         maskcs: bool = False,
-        nbghost_child: int = 4,
+        nbghost_child: int | None = 4,
     ) -> Self:
         """
         Create a NEMODataTree from a dictionary of `xarray.Dataset` objects created from NEMO model output files,
@@ -333,8 +334,9 @@ class NEMODataTree(xr.DataTree):
         vco_ref: bool = False
             If True, add reference vertical scale factors and compute reference water column heights from domain files. Default is False.
 
-        nbghost_child : int = 4
+        nbghost_child : int | None = 4
             Number of ghost cells to remove from the western/southern boundaries of the (grand)child domains. Default is 4.
+            If None, no ghost cells are removed and the full (grand)child domain is used.
 
         Returns
         -------
@@ -387,9 +389,9 @@ class NEMODataTree(xr.DataTree):
             )
         if not isinstance(vco_ref, bool):
             raise TypeError("reference vertical coordinates (`vco_ref`) must be a boolean.")
-        if not isinstance(nbghost_child, int):
+        if not isinstance(nbghost_child, (int, type(None))):
             raise TypeError(
-                "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer."
+                "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer or None."
             )
 
         # -- Define parent, child, grandchild dataset collections -- #

--- a/nemo_cookbook/processing.py
+++ b/nemo_cookbook/processing.py
@@ -58,9 +58,16 @@ def _add_parent_indices(
     i_ic = xr.DataArray(
         np.repeat(i_child, repeats=ds.attrs["rx"]),
         dims=[f"i{label}"],
-        coords={f"i{label}": ds[f"i{label}"]},
     )
+    if i_ic.size < ds[f"i{label}"].size:
+        # Pad i-mapping with NaNs if ghost cells remain in child domain:
+        width = int((ds[f"i{label}"].size - i_ic.size) / 2)
+        i_ic = i_ic.pad({f"i{label}": (width, width)})
+      
     ds[f"i{plabel}_i{label}"] = i_ic
+    ds[f"i{plabel}_i{label}"] = ds[f"i{plabel}_i{label}"].assign_coords(
+        {f"i{label}": ds[f"i{label}"]}
+        )
     ds[f"i{plabel}_i{label}"] = ds[f"i{plabel}_i{label}"].assign_attrs(
         name=f"i{plabel}_i{label}",
         long_name=f"i{plabel} indices of child domain i{label} indices",
@@ -73,9 +80,16 @@ def _add_parent_indices(
     j_jc = xr.DataArray(
         np.repeat(j_child, repeats=ds.attrs["ry"]),
         dims=[f"j{label}"],
-        coords={f"j{label}": ds[f"j{label}"]},
     )
+    if j_jc.size < ds[f"j{label}"].size:
+        # Pad j-mapping with NaNs if ghost cells remain in child domain:
+        width = int((ds[f"j{label}"].size - j_jc.size) / 2)
+        j_jc = j_jc.pad({f"j{label}": (width, width)})
+      
     ds[f"j{plabel}_j{label}"] = j_jc
+    ds[f"j{plabel}_j{label}"] =  ds[f"j{plabel}_j{label}"].assign_coords(
+        {f"j{label}": ds[f"j{label}"]}
+        )
     ds[f"j{plabel}_j{label}"] = ds[f"j{plabel}_j{label}"].assign_attrs(
         name=f"j{plabel}_j{label}",
         long_name=f"j{plabel} indices of child domain j{label} indices",
@@ -906,9 +920,10 @@ def _process_child(
     maskcs : bool = False
         If True, all closed seas are masked using mask_opensea variables from domain files. Default is False.
 
-    nbghost_child : int = _DEFAULT_NBGHOST_CHILD
+    nbghost_child : int | None = _DEFAULT_NBGHOST_CHILD
         Number of ghost cells to remove from the western/southern boundaries of the (grand)child domain.
-        Default is 4 (`_DEFAULT_NBGHOST_CHILD`).
+        Default is 4 (`_DEFAULT_NBGHOST_CHILD`). If None, no ghost cells are removed and the full
+        (grand)child domain is used.
 
     linssh: bool = False
         Linear free-surface approximation. If True, vertical coordinates are time-independent and given by
@@ -971,18 +986,23 @@ def _process_child(
         read_mask=read_mask, maskcs=maskcs, vco=vco, vco_ref=vco_ref
     )
 
-    # Get child domain indices excluding ghost cells:
-    ind_child = _get_child_indices(
-        rx=d_nests.get("rx"),
-        ry=d_nests.get("ry"),
-        imin=d_nests.get("imin"),
-        imax=d_nests.get("imax"),
-        jmin=d_nests.get("jmin"),
-        jmax=d_nests.get("jmax"),
-        nbghost_child=nbghost_child,
-    )
-    i_slice = slice(ind_child[0], ind_child[1] + 1)
-    j_slice = slice(ind_child[2], ind_child[3] + 1)
+    if nbghost_child is not None:
+        # Get child domain indices excluding ghost cells:
+        ind_child = _get_child_indices(
+            rx=d_nests.get("rx"),
+            ry=d_nests.get("ry"),
+            imin=d_nests.get("imin"),
+            imax=d_nests.get("imax"),
+            jmin=d_nests.get("jmin"),
+            jmax=d_nests.get("jmax"),
+            nbghost_child=nbghost_child,
+        )
+        i_slice = slice(ind_child[0], ind_child[1] + 1)
+        j_slice = slice(ind_child[2], ind_child[3] + 1)
+    else:
+        # Use full child domain including ghost cells:
+        i_slice = slice(None)
+        j_slice = slice(None)
 
     # Process T / U / V / W / F grids:
     d_proc_grids = {}
@@ -1077,8 +1097,9 @@ def create_datatree_dict(
         domain variables. Default is False.
     maskcs: bool = False
         If True, all closed seas are masked using mask_opensea variables from domain files. Default is False.
-    nbghost_child : int = _DEFAULT_NBGHOST_CHILD
+    nbghost_child : int | None = _DEFAULT_NBGHOST_CHILD
         Number of ghost cells to remove from the western/southern boundaries of the (grand)child domain. Default is 4 (`_DEFAULT_NBGHOST_CHILD`).
+        If None, no ghost cells are removed and the full (grand)child domain is used.
     linssh: bool = False
         Linear free-surface approximation. If True, vertical coordinates are time-independent and given by (e3t_0, e3u_0, e3v_0, e3w_0). If False, vertical
         coordinates are time-dependent and must be included in grid datasets. Default is False.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -514,86 +514,152 @@ def example_regional_nemodatatree() -> NEMODataTree:
 @pytest.fixture
 def example_ORCA2_nemodatatree() -> NEMODataTree:
     """
-    Fixture to create an example ORCA2 global NEMODataTree using AGRIF_DEMO
-    configuration. The global model domain is zonally periodic (i.e., iperio = True).
+    Fixture factory to create an example ORCA2 global NEMODataTree using AGRIF_DEMO configuration.
+    The global model domain is zonally periodic (i.e., iperio = True).
 
     Returns
     -------
     NEMODataTree
         Example ORCA2 global NEMODataTree.
     """
-    # -- Create example NEMODataTree for AGRIF_DEMO configuration -- #
-    # Get dict of example filepaths:
-    filepaths = get_filepaths("AGRIF_DEMO")
-    # Define paths dict for NEMODataTree:
-    paths = {"parent": {
-                "domain": filepaths["domain_cfg.nc"],
-                "gridT": filepaths["ORCA2_5d_00010101_00010110_grid_T.nc"],
-                "gridU": filepaths["ORCA2_5d_00010101_00010110_grid_U.nc"],
-                "gridV": filepaths["ORCA2_5d_00010101_00010110_grid_V.nc"],
-                "gridW": filepaths["ORCA2_5d_00010101_00010110_grid_W.nc"],
-                "icemod": filepaths["ORCA2_5d_00010101_00010110_icemod.nc"]
-            }}
-    # Create NEMODataTree from paths dict:
-    nemo = NEMODataTree.from_paths(paths, name="Example ORCA2", iperio=True, nftype="T")
+    def _make_nemodatatree(
+        linssh: bool = False,
+        vco: str = "1d",
+        vco_ref: bool = False,
+        ) -> NEMODataTree:
+        """
+        Fixture to create an example ORCA2 global NEMODataTree using AGRIF_DEMO
+        configuration. The global model domain is zonally periodic (i.e., iperio = True).
 
-    return nemo
+        Parameters
+        ----------
+        linssh: bool = False
+            Linear free-surface approximation. If True, vertical coordinates are time-independent and given by (e3t_0, e3u_0, e3v_0, e3w_0) in domain_cfg.
+            If False, vertical coordinates are time-dependent and must be specified in NEMO model grid datasets. Default is False.
+        vco : str = "1d"
+            Vertical reference variables. Options are '1d' to use 1-dimensional vertical reference coordinates or '3d' to use 3-dimensional
+            vertical reference coordinates (deptht, depthu, depthv, depthw, depthf). Default is '1d'.        
+        vco_ref: bool = False
+            If True, add reference vertical scale factors and compute reference water column heights from domain files. Default is False.
+
+        Returns
+        -------
+        NEMODataTree
+            Example ORCA2 global NEMODataTree.
+        """
+        # -- Create example NEMODataTree for AGRIF_DEMO configuration -- #
+        # Get dict of example filepaths:
+        filepaths = get_filepaths("AGRIF_DEMO")
+        # Define paths dict for NEMODataTree:
+        paths = {"parent": {
+                    "domain": filepaths["domain_cfg.nc"],
+                    "gridT": filepaths["ORCA2_5d_00010101_00010110_grid_T.nc"],
+                    "gridU": filepaths["ORCA2_5d_00010101_00010110_grid_U.nc"],
+                    "gridV": filepaths["ORCA2_5d_00010101_00010110_grid_V.nc"],
+                    "gridW": filepaths["ORCA2_5d_00010101_00010110_grid_W.nc"],
+                    "icemod": filepaths["ORCA2_5d_00010101_00010110_icemod.nc"]
+                }}
+        # Create NEMODataTree from paths dict:
+        nemo = NEMODataTree.from_paths(paths, name="Example ORCA2",
+                                       iperio=True,
+                                       nftype="T",
+                                       linssh=linssh,
+                                       vco=vco,
+                                       vco_ref=vco_ref
+                                       )
+
+        return nemo
+
+    return _make_nemodatatree
 
 @pytest.fixture
-def example_ORCA2_linssh_nemodatatree() -> NEMODataTree:
+def example_ORCA2_AGRIF_nemodatatree() -> NEMODataTree:
     """
-    Fixture to create an example linear free-surface ORCA2 global NEMODataTree using AGRIF_DEMO
-    configuration. The global model domain is zonally periodic (i.e., iperio = True).
+    Fixture factory to create an example nested ORCA2 global NEMODataTree.
 
     Returns
     -------
     NEMODataTree
-        Example linear free-surface ORCA2 global NEMODataTree.
+        Example nested ORCA2 global NEMODataTree.
     """
-    # -- Create example linear free-surface NEMODataTree from AGRIF_DEMO configuration -- #
-    # Get dict of example filepaths:
-    filepaths = get_filepaths("AGRIF_DEMO")
-    # Define paths dict for NEMODataTree:
-    paths = {"parent": {
-                "domain": filepaths["domain_cfg.nc"],
-                "gridT": filepaths["ORCA2_5d_00010101_00010110_grid_T.nc"],
-                "gridU": filepaths["ORCA2_5d_00010101_00010110_grid_U.nc"],
-                "gridV": filepaths["ORCA2_5d_00010101_00010110_grid_V.nc"],
-                "gridW": filepaths["ORCA2_5d_00010101_00010110_grid_W.nc"],
-                "icemod": filepaths["ORCA2_5d_00010101_00010110_icemod.nc"]
-            }}
-    # Create NEMODataTree from paths dict:
-    nemo = NEMODataTree.from_paths(paths, name="Example ORCA2", iperio=True, nftype="T", linssh=True)
+    def _make_nemodatatree(nbghost_child: int | None = 4) -> NEMODataTree:
+        """
+        Fixture to create an example nested ORCA2 global NEMODataTree including vertical grid scale factor and water column
+        references using AGRIF_DEMO configuration. The global model domain is zonally periodic (i.e., iperio = True).
+        One child and one grandchild domain are included in the NEMODataTree.
 
-    return nemo
+        Returns
+        -------
+        NEMODataTree
+            Example nested ORCA2 global NEMODataTree including vertical grid scale factor and water column references.
+        """
+        # -- Create example vco_ref NEMODataTree from AGRIF_DEMO configuration -- #
+        # Get dict of example filepaths:
+        filepaths = get_filepaths("AGRIF_DEMO")
+        # Define paths dict for NEMODataTree:
+        paths = {"parent": {
+            "domain": filepaths["domain_cfg.nc"],
+            "gridT": filepaths["ORCA2_5d_00010101_00010110_grid_T.nc"],
+            "gridU": filepaths["ORCA2_5d_00010101_00010110_grid_U.nc"],
+            "gridV": filepaths["ORCA2_5d_00010101_00010110_grid_V.nc"],
+            "gridW": filepaths["ORCA2_5d_00010101_00010110_grid_W.nc"],
+            "icemod": filepaths["ORCA2_5d_00010101_00010110_icemod.nc"]
+            },
+            "child": {
+            "1":{
+            "domain": filepaths["2_domain_cfg.nc"],
+            "gridT": filepaths["2_Nordic_5d_00010101_00010110_grid_T.nc"],
+            "gridU": filepaths["2_Nordic_5d_00010101_00010110_grid_U.nc"],
+            "gridV": filepaths["2_Nordic_5d_00010101_00010110_grid_V.nc"],
+            "gridW": filepaths["2_Nordic_5d_00010101_00010110_grid_W.nc"],
+            "icemod": filepaths["2_Nordic_5d_00010101_00010110_icemod.nc"]
+            }},
+            "grandchild": {
+            "2":{
+            "domain": filepaths["3_domain_cfg.nc"],
+            "gridT": filepaths["3_Nordic_5d_00010101_00010110_grid_T.nc"],
+            "gridU": filepaths["3_Nordic_5d_00010101_00010110_grid_U.nc"],
+            "gridV": filepaths["3_Nordic_5d_00010101_00010110_grid_V.nc"],
+            "gridW": filepaths["3_Nordic_5d_00010101_00010110_grid_W.nc"],
+            "icemod": filepaths["3_Nordic_5d_00010101_00010110_icemod.nc"]
+            }},
+            }
 
-@pytest.fixture
-def example_ORCA2_vco_ref_nemodatatree() -> NEMODataTree:
-    """
-    Fixture to create an example ORCA2 global NEMODataTree including vertical grid scale factor and water column
-    references using AGRIF_DEMO configuration. The global model domain is zonally periodic (i.e., iperio = True).
+        # Define nests dict for NEMODataTree:
+        nests = {
+            "1": {
+            "parent": "/",
+            "rx": 4,
+            "ry": 4,
+            "imin": 121,
+            "imax": 146,
+            "jmin": 113,
+            "jmax": 133,
+            "iperio": False
+            },
+            "2": {
+            "parent": "1",
+            "rx": 3,
+            "ry": 3,
+            "imin": 20,
+            "imax": 60,
+            "jmin": 27,
+            "jmax": 60,
+            "iperio": False
+            }
+            }
 
-    Returns
-    -------
-    NEMODataTree
-        Example ORCA2 global NEMODataTree including vertical grid scale factor and water column references.
-    """
-    # -- Create example vco_ref NEMODataTree from AGRIF_DEMO configuration -- #
-    # Get dict of example filepaths:
-    filepaths = get_filepaths("AGRIF_DEMO")
-    # Define paths dict for NEMODataTree:
-    paths = {"parent": {
-                "domain": filepaths["domain_cfg.nc"],
-                "gridT": filepaths["ORCA2_5d_00010101_00010110_grid_T.nc"],
-                "gridU": filepaths["ORCA2_5d_00010101_00010110_grid_U.nc"],
-                "gridV": filepaths["ORCA2_5d_00010101_00010110_grid_V.nc"],
-                "gridW": filepaths["ORCA2_5d_00010101_00010110_grid_W.nc"],
-                "icemod": filepaths["ORCA2_5d_00010101_00010110_icemod.nc"]
-            }}
-    # Create NEMODataTree from paths dict:
-    nemo = NEMODataTree.from_paths(paths, name="Example ORCA2", iperio=True, nftype="T", vco_ref=True)
+        # Create NEMODataTree from paths dict:
+        nemo = NEMODataTree.from_paths(paths=paths,
+                                       nests=nests,
+                                       iperio=True,
+                                       nftype="T",
+                                       nbghost_child=nbghost_child
+                                       )
 
-    return nemo
+        return nemo
+
+    return _make_nemodatatree
 
 @pytest.fixture
 def example_AMM12_nemodatatree() -> NEMODataTree:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -41,7 +41,7 @@ class TestGetFilepaths():
 class TestNEMODataTreeExamples():
     def test_orca2_nemodatatree(self, example_ORCA2_nemodatatree):
         # -- Create example NEMODataTree for AGRIF_DEMO configuration -- #
-        nemo = example_ORCA2_nemodatatree
+        nemo = example_ORCA2_nemodatatree(linssh=False, vco_ref=False, vco="1d")
 
         # -- Verify grid nodes, scale factors & coordinates -- #
         assert isinstance(nemo, xr.DataTree)
@@ -58,9 +58,9 @@ class TestNEMODataTreeExamples():
         # Close files associated with NEMODataTree:
         nemo.close()
 
-    def test_orca2_linssh_nemodatatree(self, example_ORCA2_linssh_nemodatatree):
+    def test_orca2_linssh_nemodatatree(self, example_ORCA2_nemodatatree):
         # -- Create example linear free-surface NEMODataTree from AGRIF_DEMO configuration -- #
-        nemo = example_ORCA2_linssh_nemodatatree
+        nemo = example_ORCA2_nemodatatree(linssh=True, vco_ref=False, vco="1d")
 
         # -- Verify grid nodes, scale factors & coordinates -- #
         assert isinstance(nemo, xr.DataTree)
@@ -77,9 +77,9 @@ class TestNEMODataTreeExamples():
         # Close files associated with NEMODataTree:
         nemo.close()
 
-    def test_orca2_vco_ref_nemodatatree(self, example_ORCA2_vco_ref_nemodatatree):
+    def test_orca2_vco_ref_nemodatatree(self, example_ORCA2_nemodatatree):
         # -- Create example vco_ref NEMODataTree from AGRIF_DEMO configuration -- #
-        nemo = example_ORCA2_vco_ref_nemodatatree
+        nemo = example_ORCA2_nemodatatree(linssh=False, vco_ref=True, vco="1d")
 
         # -- Verify grid nodes, scale factors & coordinates -- #
         assert isinstance(nemo, xr.DataTree)
@@ -91,6 +91,81 @@ class TestNEMODataTreeExamples():
             assert f"h{grid_suffix}_0" in nemo[node].data_vars
 
         # -- Tear down -- #
+        # Close files associated with NEMODataTree:
+        nemo.close()
+
+    def test_orca2_agrif_nemodatatree(self, example_ORCA2_AGRIF_nemodatatree):
+        # -- Create example nested ORCA2 global NEMODataTree from AGRIF_DEMO configuration -- #
+        nemo = example_ORCA2_AGRIF_nemodatatree(nbghost_child=4)
+
+        # -- Verify grid nodes & scale factors -- #
+        assert isinstance(nemo, xr.DataTree)
+        nodes = [entry[0] for entry in list(nemo.subtree_with_keys)]
+        for node in ['gridT', 'gridU', 'gridV', 'gridW',
+                     'gridT/1_gridT', 'gridU/1_gridU', 'gridV/1_gridV', 'gridW/1_gridW',
+                     'gridT/1_gridT/2_gridT', 'gridU/1_gridU/2_gridU', 'gridV/1_gridV/2_gridV', 'gridW/1_gridW/2_gridW'
+                     ]:
+            assert node in nodes
+            grid_suffix = node[-1].lower()
+            for factor in [f"e1{grid_suffix}", f"e2{grid_suffix}", f"e3{grid_suffix}"]:
+                assert factor in nemo[node].data_vars
+
+            # -- Verify child domain sizes & coordinates -- #
+            if "2_grid" in node:
+                # Verify coords:
+                for coord in [f"2_glam{grid_suffix}", f"2_gphi{grid_suffix}", f"2_depth{grid_suffix}"]:
+                    assert coord in nemo[node].coords
+                # Verify size(i2) = (imax - imin) * rx => (60 - 20) * 3 => 120
+                assert nemo[node]["i2"].size == 120
+                # Verify size(j2) = (jmax - jmin) * ry => (60 - 27) * 3 => 99
+                assert nemo[node]["j2"].size == 99
+            elif "1_grid" in node:
+                # Verify coords:
+                for coord in [f"1_glam{grid_suffix}", f"1_gphi{grid_suffix}", f"1_depth{grid_suffix}"]:
+                    assert coord in nemo[node].coords
+                # Verify size(i1) = (imax - imin) * rx => (146 - 121) * 4 => 100
+                assert nemo[node]["i1"].size == 100
+                # Verify size(j1) = (jmax - jmin) * ry => (133 - 113) * 4 => 80
+                assert nemo[node]["j1"].size == 80
+
+        # Close files associated with NEMODataTree:
+        nemo.close()
+
+
+    def test_orca2_agrif_nbghost_child_nemodatatree(self, example_ORCA2_AGRIF_nemodatatree):
+        # -- Create example nested ORCA2 global NEMODataTree from AGRIF_DEMO configuration -- #
+        nemo = example_ORCA2_AGRIF_nemodatatree(nbghost_child=None)
+
+        # -- Verify grid nodes & scale factors -- #
+        assert isinstance(nemo, xr.DataTree)
+        nodes = [entry[0] for entry in list(nemo.subtree_with_keys)]
+        for node in ['gridT', 'gridU', 'gridV', 'gridW',
+                     'gridT/1_gridT', 'gridU/1_gridU', 'gridV/1_gridV', 'gridW/1_gridW',
+                     'gridT/1_gridT/2_gridT', 'gridU/1_gridU/2_gridU', 'gridV/1_gridV/2_gridV', 'gridW/1_gridW/2_gridW'
+                     ]:
+            assert node in nodes
+            grid_suffix = node[-1].lower()
+            for factor in [f"e1{grid_suffix}", f"e2{grid_suffix}", f"e3{grid_suffix}"]:
+                assert factor in nemo[node].data_vars
+
+            # -- Verify child domain sizes & coordinates -- #
+            if "2_grid" in node:
+                # Verify coords:
+                for coord in [f"2_glam{grid_suffix}", f"2_gphi{grid_suffix}", f"2_depth{grid_suffix}"]:
+                    assert coord in nemo[node].coords
+                # Verify size(i2) = (imax - imin) * rx + 2 * nbghost_child => (60 - 20) * 3 + 8 => 128
+                assert nemo[node]["i2"].size == 128
+                # Verify size(j2) = (jmax - jmin) * ry + 2 * nbghost_child => (60 - 27) * 3 + 8 => 107
+                assert nemo[node]["j2"].size == 107
+            elif "1_grid" in node:
+                # Verify scale factors:
+                for coord in [f"1_glam{grid_suffix}", f"1_gphi{grid_suffix}", f"1_depth{grid_suffix}"]:
+                    assert coord in nemo[node].coords
+                # Verify size(i1) = (imax - imin) * rx + 2 * nbghost_child => (146 - 121) * 4 + 8 => 108
+                assert nemo[node]["i1"].size == 108
+                # Verify size(j1) = (jmax - jmin) * ry + 2 * nbghost_child => (133 - 113) * 4 + 8 => 88
+                assert nemo[node]["j1"].size == 88
+
         # Close files associated with NEMODataTree:
         nemo.close()
 

--- a/tests/test_nemodatatree.py
+++ b/tests/test_nemodatatree.py
@@ -90,10 +90,10 @@ class TestNEMODataTreePaths():
         with pytest.raises(TypeError, match=re.escape("reference vertical coordinates (`vco_ref`) must be a boolean.")):
             NEMODataTree.from_paths(paths={}, vco_ref=vco_ref)
 
-    @pytest.mark.parametrize("nbghost_child", ["1", 1.5, None])
+    @pytest.mark.parametrize("nbghost_child", ["1", 1.5, [4]])
     def test_nbghost_child_errors(self, nbghost_child):
         # -- Verify TypeError -- #
-        expected_str = "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer."
+        expected_str = "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer or None."
         with pytest.raises(TypeError, match=re.escape(expected_str)):
             NEMODataTree.from_paths(paths={}, nbghost_child=nbghost_child)
 
@@ -202,10 +202,10 @@ class TestNEMODataTreeDatasets():
         with pytest.raises(TypeError, match=re.escape(expected_str)):
             NEMODataTree.from_datasets(datasets={}, vco_ref=vco_ref)
 
-    @pytest.mark.parametrize("nbghost_child", ["1", 1.5, None])
+    @pytest.mark.parametrize("nbghost_child", ["1", 1.5, [4]])
     def test_nbghost_child_errors(self, nbghost_child):
         # -- Verify TypeError -- #
-        expected_str = "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer."
+        expected_str = "number of ghost cells along the western/southern boundaries (`nbghost_child`) must be an integer or None."
         with pytest.raises(TypeError, match=re.escape(expected_str)):
             NEMODataTree.from_datasets(datasets={}, nbghost_child=nbghost_child)
 


### PR DESCRIPTION
### Retain ghost points in nested NEMODataTrees including a hierarchy of domains.

- [x] Added option to use `nbghost_child=None` in `from_paths()` and `from_datasets()` constructors to enable users to optionally bypass clipping ghost points in child domains.
- [x] Updated the `processing.py` module `_get_child_indices()` function to fill ghost point parent indices with NaN values when located outside of the domain defined in the input `nests` dictionary.
- [x] Added new fixture factories to generate ORCA2 and ORCA2-AGRIF example NEMODataTree for unit testing.
- [x] Added new unit tests to verify behaviour when `nbghost_child=None` - ghost points are retained.
- [x] Updated documentation to reflect `linssh` parameter rename and include discussion on the use of `vco` when constructing a NEMODataTree.

Closes Issue #47 