### PR TITLE
60 feature add merge and concat methods to combine nemodatatrees

### DIFF
--- a/nemo_cookbook/nemodataarray.py
+++ b/nemo_cookbook/nemodataarray.py
@@ -909,8 +909,9 @@ class NEMODataArray:
         )
 
         # -- Define integral variable DataArray -- #
-        dim_list = [dim for dim in [self.t_name, "k_new", self.j_name, self.i_name] if (dim is not None) and (dim in result.dims)]
-        result = result.transpose(*dim_list).squeeze(dim="k_new")
+        dims = [dim if dim != "k" else "k_new" for dim in self.dims]
+        result_dims = [dim for dim in dims if dim in result.dims]
+        result = result.transpose(*result_dims).squeeze(dim="k_new")
         result.name = f"integral_z({self.name})"
 
         # -- Apply land-sea mask & return NEMODataArray -- #
@@ -1105,8 +1106,8 @@ class NEMODataArray:
         result.name = da.name
 
         # Reorder dimensions (time_counter, [k], j, i):
-        var_dims = [dim for dim in [self.t_name, self.k_name, self.j_name, self.i_name] if (dim is not None) and (dim in result.dims)]
-        result = result.transpose(*var_dims)
+        result_dims = [dim for dim in self.dims if dim in result.dims]
+        result = result.transpose(*result_dims)
 
         # Normalise by target grid cell weights for flux variables:
         if self._grid_suffix.upper() in ["U", "V"]:
@@ -1192,10 +1193,11 @@ class NEMODataArray:
         )
 
         # -- Construct transformed variable Dataset -- #
-        var_dims = [dim for dim in [self.t_name, "k_new", self.j_name, self.i_name] if (dim is not None) and (dim in var_out.dims)]
+        dims = [dim if dim != "k" else "k_new" for dim in self.dims]
+        var_dims = [dim for dim in dims if dim in var_out.dims]
         var_out = var_out.transpose(*var_dims)
     
-        e3_dims = [dim for dim in [self.t_name, "k_new", self.j_name, self.i_name] if (dim is not None) and (dim in e3_out.dims)]
+        e3_dims = [dim for dim in dims if dim in e3_out.dims]
         e3_out = e3_out.transpose(*e3_dims)
 
         result = xr.Dataset(
@@ -1559,32 +1561,31 @@ class NEMODataArray:
 
     def __repr__(self) -> str:
         return (
-            f"<NEMODataTree '{self._tree.name or 'unnamed'}'>\n"
-            f"  <NEMODataArray '{self.name or 'unnamed'}' (Domain: '{self._dom}', "
-            f"Grid: '{self._grid}', Grid Type: '{self._grid_suffix.upper()}')>\n\n"
+            f"<NEMODataTree  '{self._tree.name or 'unnamed'}' "
+            f"(Domain: '{self._dom}', Grid: '{self._grid}', Grid Type: '{self._grid_suffix.upper()}')>\n\n"
             f"{repr(self._da)}"
         )
 
     def _repr_html_(self) -> str:
         banner = f"""
-        <div style="margin-bottom: 10px;">
-            <div">
-                <span style="color:#6a737d;">NEMODataTree</span> '{self._tree.name or "unnamed"}'
+        <div style="margin-bottom:10px;">
+            <div style="display:flex; align-items:center;
+                        padding-bottom:8px; margin-bottom:8px;
+                        border-bottom:1px solid #d0d7de;">
+                <span style="color:#6a737d; margin-right:12px;">NEMODataTree</span>
+                '{self._tree.name or "unnamed"}'
             </div>
 
-            <div style="margin-left: 18px; margin-top:4px;">
-                <span style="color:#6a737d;">NEMODataArray</span> '{self.name or "unnamed"}'
-                <div>├─ <strong>Domain:</strong> '{self._dom}'</div>
-                <div>├─ <strong>Grid Path:</strong> '{self._grid}'</div>
-                <div>└─ <strong>Grid Type:</strong> '{self._grid_suffix.upper()}'</div>
-            </div>
+            <div><span style="font-family:monospace;">├─</span> <strong>Domain:</strong> '{self._dom}'</div>
+            <div><span style="font-family:monospace;">├─</span> <strong>Grid Path:</strong> '{self._grid}'</div>
+            <div><span style="font-family:monospace;">└─</span> <strong>Grid Type:</strong> '{self._grid_suffix.upper()}'</div>
         </div>
         """
 
         return f"""
-        <div style="border:1px solid #ddd; padding:12px; border-radius:8px;">
+        <div style="padding:12px;">
             {banner}
-            {self.data._repr_html_()}
+            {self.data._repr_html_().replace("xarray.DataArray", "NEMODataArray")}
         </div>
         """
 

--- a/nemo_cookbook/nemodatatree.py
+++ b/nemo_cookbook/nemodatatree.py
@@ -28,7 +28,6 @@ from nemo_cookbook.masks import create_polygon_mask, get_mask_boundary
 from nemo_cookbook.nemodataarray import NEMODataArray
 from nemo_cookbook.processing import create_datatree_dict
 from nemo_cookbook.stats import compute_binned_statistic
-from nemo_cookbook.utils import deprecated
 from nemo_cookbook.validation import validate_nemo_grid_node
 
 
@@ -594,6 +593,117 @@ class NEMODataTree(xr.DataTree):
                                 "iperio": iperio or datatree["/"].attrs.get("iperio", False)
                                 })
         nemo.name = name or datatree["/"].attrs.get("name", None)
+
+        # -- Validate NEMO grid node Datasets -- #
+        for key in [grid for grid in nemo.groups if grid.startswith("grid")]:
+            validate_nemo_grid_node(key=key, value=nemo[key])
+
+        return nemo
+
+    def merge(self, trees: list[Self], **kwargs) -> Self:
+        """
+        Merge any number of NEMODataTree objects into a single NEMODataTree.
+
+        Parameters
+        ----------
+        trees : list[NEMODataTree]
+            Merge together all variables in these NEMODataTree objects.
+        **kwargs
+            Additional keyword arguments passed to xarray.merge.
+
+        Returns
+        -------
+        NEMODataTree
+            NEMODataTree with combined variables from the inputs.
+
+        Examples
+        --------
+        Merge the variables from two NEMODataTree objects `nemo` and `nemo_other` into a single NEMODataTree `nemo_merged`:
+
+        >>> nemo_merged = nemo.merge([nemo_other], compat="no_conflicts")
+
+        See Also
+        --------
+        concat
+        """
+        # -- Validate Input -- #
+        if not (isinstance(trees, list) and all(isinstance(tree, NEMODataTree) for tree in trees)):
+            raise TypeError("trees must be a list of NEMODataTree objects to merge into a single NEMODataTree")
+
+        # Merge NEMODataTree underyling xarray.DataTrees:
+        datatree = xr.merge(objects=[self] + trees, **kwargs)
+
+        # Convert the resulting xarray.DataTree into a NEMODataTree:
+        nemo = super().from_dict(datatree.to_dict())
+
+        # -- Update NEMODataTree properties -- #
+        nemo["/"].attrs.update({"nftype": datatree["/"].attrs.get("nftype", None),
+                                "iperio": datatree["/"].attrs.get("iperio", False)
+                                })
+        nemo.name = datatree["/"].attrs.get("name", None)
+
+        # -- Validate NEMO grid node Datasets -- #
+        for key in [grid for grid in nemo.groups if grid.startswith("grid")]:
+            validate_nemo_grid_node(key=key, value=nemo[key])
+
+        return nemo
+
+    def concat(self, trees: list[Self], dim: str | xr.DataArray, **kwargs) -> Self:
+        """
+        Concatenate any number of NEMODataTree objects along a new or existing dimension.
+
+        Parameters
+        ----------
+        trees : list[NEMODataTree]
+            Concatenate together all variables in these NEMODataTree objects.
+        dim : str | xr.DataArray
+            Dimension along which to concatenate the NEMODataTree objects. This can either be a new dimension name,
+            in which case it is added along axis=0, or an existing dimension name, in which case the location of the
+            dimension is unchanged. If dimension is provided as an xarray.DataArray, its name is used as the dimension
+            to concatenate along and its values are added as a coordinate.
+        **kwargs
+            Additional keyword arguments passed to xarray.concat.
+
+        Returns
+        -------
+        NEMODataTree
+            NEMODataTree with concatenated variables from the inputs.
+
+        Examples
+        --------
+        Concatenate two NEMODataTree objects `nemo` and `nemo_other` along an existing dimension `time_counter`:
+
+        >>> nemo_concat = nemo.concat([nemo_other], dim="time_counter")
+
+        Concatenate two NEMODataTree objects `nemo` and `nemo_other` representing ensemble members along a new dimension `ens`:
+
+        >>> ens = xr.DataArray(data=[1,2],
+        ...                    dims="ens",
+        ...                    coords={"ens": ("ens", [1,2])}
+        ...                    )
+        >>> nemo_concat = nemo.concat([nemo_other], dim=ens)
+
+        See Also
+        --------
+        merge
+        """
+        # -- Validate Input -- #
+        if not (isinstance(trees, list) and all(isinstance(tree, NEMODataTree) for tree in trees)):
+            raise TypeError("trees must be a list of NEMODataTree objects to concatenate along a given dimension")
+        if not isinstance(dim, (str, xr.DataArray)):
+            raise TypeError("dim must be a string or an xarray.DataArray specifying the dimension to concatenate along")
+
+        # Concatenate NEMODataTree underlying xarray.DataTrees:
+        datatree = xr.concat(objs=[self] + trees, dim=dim, **kwargs)
+
+        # Convert the resulting xarray.DataTree into a NEMODataTree:
+        nemo = super().from_dict(datatree.to_dict())
+
+        # -- Update NEMODataTree properties -- #
+        nemo["/"].attrs.update({"nftype": datatree["/"].attrs.get("nftype", None),
+                                "iperio": datatree["/"].attrs.get("iperio", False)
+                                })
+        nemo.name = datatree["/"].attrs.get("name", None)
 
         # -- Validate NEMO grid node Datasets -- #
         for key in [grid for grid in nemo.groups if grid.startswith("grid")]:

--- a/tests/test_nemodatatree_core.py
+++ b/tests/test_nemodatatree_core.py
@@ -15,9 +15,85 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from nemo_cookbook import NEMODataArray
+from nemo_cookbook import NEMODataArray, NEMODataTree
 
 
+class TestNEMODataTreeMerge():
+    @pytest.mark.parametrize("trees", [["nemo", "nemo_other"], (xr.DataTree(), xr.DataTree())])
+    def test_trees_errors(self, trees, example_global_nemodatatree):
+        # -- Verify TypeError -- #
+        expected_str = "trees must be a list of NEMODataTree objects to merge into a single NEMODataTree"
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            example_global_nemodatatree.merge(trees)
+    @pytest.mark.parametrize("dom_type", ["global", "regional"])
+    def test_merge(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
+        # -- Select NEMODataTree based on domain type -- #
+        match dom_type:
+            case "regional":
+                nemo = example_regional_nemodatatree
+                nemo_partial = example_regional_nemodatatree.copy()
+            case "global":
+                nemo = example_global_nemodatatree
+                nemo_partial = example_global_nemodatatree.copy()
+            case _:
+                raise ValueError("dom_type must be 'global' or 'regional'")
+
+        # -- Prepare partially complete NEMODataTrees for merge -- #
+        nemo["gridT"] = nemo["gridT"].dataset.drop_vars(["tos_con"])
+        nemo_partial["gridT"] = nemo_partial["gridT"].dataset.drop_vars(["thetao_con"])
+
+        # -- Verify NEMODataTree is returned -- #
+        nemo_merged = nemo.merge([nemo_partial], compat="no_conflicts")
+        assert isinstance(nemo_merged, NEMODataTree)
+        for node in nemo.groups:
+            assert node in nemo_merged.groups
+
+        # -- Verify variables have been correctly merged -- #
+        assert "tos_con" in nemo_merged["gridT"].data_vars
+        assert "thetao_con" in nemo_merged["gridT"].data_vars
+        assert nemo["gridT"]["thetao_con"].equals(nemo_merged["gridT"]["thetao_con"])
+        assert nemo_partial["gridT"]["tos_con"].equals(nemo_merged["gridT"]["tos_con"])
+
+class TestNEMODataTreeConcat():
+    @pytest.mark.parametrize("trees", [["nemo", "nemo_other"], (xr.DataTree(), xr.DataTree())])
+    def test_trees_errors(self, trees, example_global_nemodatatree):
+        # -- Verify TypeError -- #
+        expected_str = "trees must be a list of NEMODataTree objects to concatenate along a given dimension"
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            example_global_nemodatatree.concat(trees, dim="ens")
+    @pytest.mark.parametrize("dim", [["ens"], {"ens": [1,2]}])
+    def test_dim_error(self, dim, example_global_nemodatatree):
+        # -- Verify TypeError -- #
+        expected_str = "dim must be a string or an xarray.DataArray specifying the dimension to concatenate along"
+        with pytest.raises(TypeError, match=re.escape(expected_str)):
+            example_global_nemodatatree.concat(trees=[example_global_nemodatatree], dim=dim)
+    @pytest.mark.parametrize("dom_type", ["global", "regional"])
+    def test_concat(self, dom_type, example_global_nemodatatree, example_regional_nemodatatree):
+        # -- Select NEMODataTree based on domain type -- #
+        match dom_type:
+            case "regional":
+                nemo = example_regional_nemodatatree
+            case "global":
+                nemo = example_global_nemodatatree
+            case _:
+                raise ValueError("dom_type must be 'global' or 'regional'")
+
+        # -- Prepare new ensemble dimension for concatenation -- #
+        ens = xr.DataArray(data=[1,2],
+                           dims="ens",
+                           coords={"ens": ("ens", [1,2])}
+                           )
+
+        # -- Verify NEMODataTree is returned -- #
+        nemo_concat = nemo.concat([nemo], dim=ens)
+        assert isinstance(nemo_concat, NEMODataTree)
+
+        # -- Verify new ensemble dimension exists -- #
+        for node in nemo.groups:
+            assert node in nemo_concat.groups
+            assert "ens" in nemo_concat[node].dims
+            assert nemo_concat[node].sizes["ens"] == 2
+        
 class TestCellArea():
     @pytest.mark.parametrize(
             "dom_type, grid",


### PR DESCRIPTION
### Add new `merge` and `concat` methods to combine multiple `NEMODataTree` objects.

- [x] Added `.merge(trees, **kwargs)` method to `NEMODataTree` to allow users to combine variables stored in the current `NEMODataTree` with one or more `NEMODataTree` objects. This is a thin wrapper around `xarray.merge()` which then reassembles the `NEMODataTree`, meaning **kwargs are arguments which are passed to `xarray.merge()` directly.

- [x] Added `.concat(trees, dim, **kwargs)` method to `NEMODataTree` to allow users to combine one or more `NEMODataTree` objects along a specified dimension. This is a thin wrapper around `xarray.concat()` which then reassembles the `NEMODataTree`, meaning **kwargs are arguments which are passed to `xarray.concat()` directly. Like the original `xarray.concat()` method, we allow both the name of the dimension or a new dimension (`xarray.DataArray`) to be passed as `dim`.

- [x] Added unit tests in `TestNEMODataTreeMerge` and `TestNEMODataTreeConcat` classes.

- [x] Updated `NEMODataArray` html representation in notebooks. 

- [x] Updated core dimension handling in `NEMODataArray` transpose operations to support additional dimensions, such as ensemble members introduced using `NEMODataTree.concat()`.

Closes #60 